### PR TITLE
Allow templates to show up in multiple categories

### DIFF
--- a/ci/android.properties.json
+++ b/ci/android.properties.json
@@ -2,5 +2,5 @@
     "name": "Android",
     "description": "Build an Android project with Gradle.",
     "iconName": "android",
-    "category": "Mobile"
+    "category": ["Java", "Mobile"]
 }

--- a/ci/ant.properties.json
+++ b/ci/ant.properties.json
@@ -2,5 +2,5 @@
     "name": "Ant",
     "description": "Build and test a Java project with Apache Ant.",
     "iconName": "ant",
-    "category": "Java"
+    "category": ["Ant Build System", "Java"]
 }

--- a/ci/asp.net-core.properties.json
+++ b/ci/asp.net-core.properties.json
@@ -2,5 +2,5 @@
     "name": "ASP.NET Core",
     "description": "Build and test an ASP.NET Core project targeting .NET Core.",
     "iconName": "dotnetcore",
-    "category": ".NET"
+    "category": ["ASP"]
 }

--- a/ci/c-cpp.properties.json
+++ b/ci/c-cpp.properties.json
@@ -2,5 +2,5 @@
     "name": "C/C++ with Make",
     "description": "Build and test a C/C++ project using Make.",
     "iconName": "c-cpp",
-    "category": null
+    "category": ["C", "C++"]
 }

--- a/ci/clojure.properties.json
+++ b/ci/clojure.properties.json
@@ -2,5 +2,5 @@
     "name": "Clojure",
     "description": "Build and test a Clojure project with Leiningen.",
     "iconName": "clojure",
-    "category": null
+    "category": ["Clojure", "Java"]
 }

--- a/ci/crystal.properties.json
+++ b/ci/crystal.properties.json
@@ -2,5 +2,5 @@
     "name": "Crystal",
     "description": "Build and test a Crystal project.",
     "iconName": "crystal",
-    "category": null
+    "category": ["Crystal"]
 }

--- a/ci/dart.properties.json
+++ b/ci/dart.properties.json
@@ -2,5 +2,5 @@
     "name": "Dart",
     "description": "Build and test a Dart project with Pub.",
     "iconName": "dart",
-    "category": null
+    "category": ["Dart"]
 }

--- a/ci/docker-image.properties.json
+++ b/ci/docker-image.properties.json
@@ -2,5 +2,5 @@
     "name": "Docker image",
     "description": "Build a Docker image to deploy, run, or push to a registry.",
     "iconName": "docker",
-    "category": null
+    "category": ["Dockerfile"]
 }

--- a/ci/elixir.properties.json
+++ b/ci/elixir.properties.json
@@ -2,5 +2,5 @@
     "name": "Elixir",
     "description": "Build and test an Elixir project with Mix.",
     "iconName": "elixir",
-    "category": null
+    "category": ["Elixir", "Erlang"]
 }

--- a/ci/erlang.properties.json
+++ b/ci/erlang.properties.json
@@ -2,5 +2,5 @@
     "name": "Erlang",
     "description": "Build and test an Erlang project with rebar.",
     "iconName": "erlang",
-    "category": null
+    "category": ["Erlang"]
 }

--- a/ci/gradle.properties.json
+++ b/ci/gradle.properties.json
@@ -2,5 +2,5 @@
     "name": "Gradle",
     "description": "Build and test a Java project using a Gradle wrapper script.",
     "iconName": "gradle",
-    "category": "Java"
+    "category": ["Java"]
 }

--- a/ci/haskell.properties.json
+++ b/ci/haskell.properties.json
@@ -2,5 +2,5 @@
     "name": "Haskell",
     "description": "Build and test a Haskell project with Cabal.",
     "iconName": "haskell",
-    "category": null
+    "category": ["Haskell"]
 }

--- a/ci/jekyll.properties.json
+++ b/ci/jekyll.properties.json
@@ -2,5 +2,5 @@
     "name": "Jekyll",
     "description": "Package a Jekyll site using the jekyll/builder Docker image.",
     "iconName": "jekyll",
-    "category": "HTML"
+    "category": ["HTML"]
 }

--- a/ci/maven.properties.json
+++ b/ci/maven.properties.json
@@ -2,5 +2,5 @@
     "name": "Maven",
     "description": "Build and test a Java project with Apache Maven.",
     "iconName": "maven",
-    "category": "Java"
+    "category": ["Java"]
 }

--- a/ci/node.js.properties.json
+++ b/ci/node.js.properties.json
@@ -2,5 +2,5 @@
     "name": "Node.js",
     "description": "Build and test a Node.js project with npm.",
     "iconName": "nodejs",
-    "category": "JavaScript"
+    "category": ["JavaScript"]
 }

--- a/ci/python-django.properties.json
+++ b/ci/python-django.properties.json
@@ -2,5 +2,5 @@
     "name": "Python Django",
     "description": "Test a Django project on multiple versions of Python.",
     "iconName": "django",
-    "category": "Python"
+    "category": ["Python", "HTML+Django"]
 }

--- a/ci/python-package.properties.json
+++ b/ci/python-package.properties.json
@@ -2,5 +2,5 @@
     "name": "Python package",
     "description": "Create and test a Python package on multiple Python versions.",
     "iconName": "python",
-    "category": "Python"
+    "category": ["Python"]
 }

--- a/ci/rust.properties.json
+++ b/ci/rust.properties.json
@@ -2,5 +2,5 @@
     "name": "Rust",
     "description": "Build and test a Rust project with Cargo.",
     "iconName": "rust",
-    "category": null
+    "category": ["Rust"]
 }


### PR DESCRIPTION
We'll get a language returned by the language detection on the repo. However some templates work in more than one case or language, for example the `C/C++ with Make` template. This changes category to an array so that we can have a template show up in more than one place and makes some guesses when this would be appropriate.

Supports github/dreamlifter#953