### PR TITLE
Use correct sdk version

### DIFF
--- a/ci/asp.net-core.yml
+++ b/ci/asp.net-core.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@master
       with:
-        version: 2.2.6
+        version: 2.2.108
 
     - name: Build with dotnet
       run: dotnet build --configuration Release


### PR DESCRIPTION
Right now, this template fails out of the box. That's because it references the ASP.NET Core version, not the .NET Core SDK (see [here](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.6/2.2.6-download.md)).

Is there any follow up work that needs to happen for this to propogate to the templates? Not sure how that process works