### PR TITLE
Update templates to use v1 tag

### DIFF
--- a/ci/android.yml
+++ b/ci/android.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: set up JDK 1.8
-      uses: actions/setup-java@master
+      uses: actions/setup-java@v1
       with:
         version: 1.8
 

--- a/ci/ant.yml
+++ b/ci/ant.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@master
+      uses: actions/setup-java@v1
       with:
         version: 1.8
 

--- a/ci/asp.net-core.yml
+++ b/ci/asp.net-core.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
     
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@master
+      uses: actions/setup-dotnet@v1
       with:
         version: 2.2.108
 

--- a/ci/go.yml
+++ b/ci/go.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.12
-      uses: actions/setup-go@master
+      uses: actions/setup-go@v1
       with:
         version: 1.12
       id: go

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@master
+      uses: actions/setup-java@v1
       with:
         version: 1.8
 

--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@master
+      uses: actions/setup-java@v1
       with:
         version: 1.8
 

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Use Node.js 10.x
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v1
       with:
         version: 10.x
 

--- a/ci/python-django.yml
+++ b/ci/python-django.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v1
       with:
         version: 3.6
 

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v1
       with:
         version: ${{ matrix.python-version }}
 

--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@master
+      uses: actions/setup-ruby@v1
       with:
         version: 2.6.x
 

--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
 
     - name: Build
       run: cargo build --verbose

--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
 
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
Right now, all the templates are pinned to master, its in general a better practice to pin to a tag though (which won't have breaking changes). This updates that for everything except checkout (which just uses a plugin).

Fixes #7 