### PR TITLE
Use container job in Elixir template

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -1,21 +1,21 @@
-on: [push]
+on: push
 
-name: Elixir
+name: CI
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    container:
+      image: elixir:1.9.1-slim
+
     steps:
-
     - uses: actions/checkout@master
-    
-    - name: Install dependencies
+    - name: Install Dependencies
       run: |
-        mix local.rebar --force;
-        mix local.hex --force;
+        mix local.rebar --force
+        mix local.hex --force
         mix deps.get
-
-    - name: Run tests
+    - name: Run Tests
       run: mix test


### PR DESCRIPTION
This updates the Elixir template to use a container job. Since Elixir isn't installed on a VM by default, we can use a container job to run Elixir test suites.

Verified this template in [bbq-beets/test-elixir](https://github.com/bbq-beets/test-elixir/commit/42ae6a00aea1bb648969fcc2a3f9c7f348058589/checks).