### PR TITLE
Go template - use->uses

### DIFF
--- a/ci/go.yml
+++ b/ci/go.yml
@@ -14,7 +14,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      use: actions/checkout@master
+      uses: actions/checkout@master
       path: ${{ go.module-path }}
 
     - name: Get dependencies


### PR DESCRIPTION
Fixes a small bug in the template, `use` should be `uses`