### PR TITLE
Fix linux file permission issues with Gemfile.lock

### DIFF
--- a/ci/jekyll.yml
+++ b/ci/jekyll.yml
@@ -13,5 +13,4 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest \
-        jekyll build --future
+        jekyll/builder:latest /bin/bash -c "chmod 777 srv/jekyll && jekyll build --future"


### PR DESCRIPTION
This will error out because `Gemfile.lock` doesn't have the right permissions in the `/srv/jekyll` dir.

```
There was an error while trying to write to `/srv/jekyll/Gemfile.lock`. It is
likely that you need to grant write permissions for that path.
```

To reproduce, run this workflow on a jekyll site repo.

After some experimenting, I've found that `chmod`ing the folder 777 fixes this issue.

(see https://github.com/pmarsceill/just-the-docs/pull/170/checks?sha=996a729ffc72b4951f1efd674e6974aefdf3de41)

