### PR TITLE
Test node in all current versions

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -7,12 +7,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
     steps:
     - uses: actions/checkout@master
-    - name: Use Node.js 10.x
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        version: 10.x
+        version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
         npm install


### PR DESCRIPTION
Node packages should be tested in all current versions by default.  We are working on setting some guidelines as mentioned in https://github.com/actions/setup-node/issues/25, so until aliases are supported we would want to keep this list up to date with the node LTS plan: https://nodejs.org/en/about/releases/

As I am not in the beta, I do not have the ability to try these out, but I wanted to make sure we setup people up with the best practice from day one, so figured I would get this in early.  I copied from the python example, so think it should work but am happy to make any changes necessary to get this merged.