### PR TITLE
Fix arguments for go-sample workflow in step checkout

### DIFF
--- a/ci/go.yml
+++ b/ci/go.yml
@@ -15,7 +15,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@master
-      path: ${{ go.module-path }}
+      with:
+        path: ${{ go.module-path }}
 
     - name: Get dependencies
       working-directory: ${{ go.module-path }}


### PR DESCRIPTION
Set argument `path` for action using `with` as documented.

https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepswith
