### PR TITLE
Add "Lint with flake8" step to detect Python syntax errors

### DIFF
--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -21,6 +21,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pip install pytest


### PR DESCRIPTION
These core [__flake8__](http://flake8.pycqa.org/en/latest/) tests can quickly find Python syntax errors and undefined names.

__flake8__ avoids the false positives that __pylint__ is so famous for:
* https://lukeplant.me.uk/blog/posts/pylint-false-positives

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these __tests are focused on runtime safety and correctness__:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  __Use ==/!= to compare str, bytes, and int literals__ is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.