### PR TITLE
Node workflow - force Jest to run in CI-mode

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -21,4 +21,4 @@ jobs:
       run: |
         npm install
         npm run build --if-present
-        npm test
+        CI=true npm test

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -21,4 +21,6 @@ jobs:
       run: |
         npm install
         npm run build --if-present
-        CI=true npm test
+        npm test
+      env:
+        CI: true


### PR DESCRIPTION
Ran into an issue using this workflow where our `npm test` step would hang awaiting input, something like
```
...
2019-08-15T20:30:10.3557212Z > react-scripts test --env=jsdom
2019-08-15T20:30:10.3557447Z 
2019-08-15T20:30:13.4856720Z No tests found related to files changed since last commit.
2019-08-15T20:30:13.4857633Z Press `a` to run all tests, or run Jest with `--watchAll`.
2019-08-15T20:30:13.4896414Z 
2019-08-15T20:30:13.4896619Z Watch Usage
2019-08-15T20:30:13.4897107Z  › Press a to run all tests.
2019-08-15T20:30:13.4897681Z  › Press p to filter by a filename regex pattern.
2019-08-15T20:30:13.4898265Z  › Press t to filter by a test name regex pattern.
2019-08-15T20:30:13.4898676Z  › Press q to quit watch mode.
2019-08-15T20:30:13.4898970Z  › Press Enter to trigger a test run.
...
```
Courtesy [Stack Overflow](https://stackoverflow.com/a/51609302), this PR proposes [forcing Jest to run in CI-mode, and tests will only run once instead of launching the watcher.](https://create-react-app.dev/docs/running-tests#linux-macos-bash)

-----
_I don't know much about Javascript stuff, is this specific to React?_