### PR TITLE
Fix dart workflow

### DIFF
--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     
+    container:
+      image:  google/dart:latest
+    
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies


### PR DESCRIPTION
The dart runtime is not installed by default. The action failes with an error.