### PR TITLE
update Erlang workflow to rebar3

### DIFF
--- a/ci/erlang.yml
+++ b/ci/erlang.yml
@@ -8,11 +8,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container:
+      image: erlang:22.0.7
+
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: rebar get-deps
     - name: Compile
-      run: rebar compile
+      run: rebar3 compile
     - name: Run tests
-      run: rebar skip_deps=true eunit
+      run: rebar3 do eunit, ct


### PR DESCRIPTION
[rebar](https://github.com/rebar/rebar) has been deprecated for a few years now and [rebar3](https://github.com/erlang/rebar3) has taken its place.

Since rebar3 no longer has a separate step for fetching dependencies so this step is removed. Common Test is enabled in the test run so it will run all tests.

The Erlang docker image is used instead of ubuntu because ubuntu has no package for rebar3.