### PR TITLE
Publish Python package to PyPI workflow

### DIFF
--- a/ci/properties/python-publish.properties.json
+++ b/ci/properties/python-publish.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Publish Python Package",
+    "description": "Publish a Python Package to PyPI on release.",
+    "iconName": "python",
+    "categories": ["Python"]
+}

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -1,6 +1,8 @@
 name: Upload Python Package
 
-on: [release]
+on:
+  release:
+    types: [created]
 
 jobs:
   deploy:
@@ -8,17 +10,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      if: github.event.action == 'created'
       uses: actions/setup-python@v1
       with:
         python-version: '3.x'
     - name: Install dependencies
-      if: github.event.action == 'created'
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Build and publish
-      if: github.event.action == 'created'
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -1,0 +1,27 @@
+name: Upload Python Package
+
+on: [release]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      if: github.event.action == 'created'
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      if: github.event.action == 'created'
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      if: github.event.action == 'created'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Publishing a Python package directly to [PyPI](https://pypi.org/) when you create a release is a really common use case for CI. I think including this as a starter workflow will be very useful for when GitHub Actions is released to everyone.