### PR TITLE
Use cron for labeler trigger

### DIFF
--- a/automation/label.yml
+++ b/automation/label.yml
@@ -1,5 +1,7 @@
 name: Labeler
-on: [pull_request]
+on:
+  schedule:
+  - cron: "0 * * * *"
 
 jobs:
   label:


### PR DESCRIPTION
We can't give write permissions to forks, so we want to just run this from the default branch on a recurring schedule