### PR TITLE
Add JRE+Clojure to Clojure starter template

### DIFF
--- a/ci/clojure.yml
+++ b/ci/clojure.yml
@@ -4,9 +4,8 @@ on: [push]
 
 jobs:
   build:
- 
     runs-on: ubuntu-latest
-    
+    container: clojure
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies


### PR DESCRIPTION
I took a look at this starter template and it seemed odd that it was missing Clojure itself (and a JRE, which Clojure requires).

I’m not sure if it’s desirable for these starter templates to use Docker containers, but this seems to me to be the easiest way to get the JRE and Clojure (along with `lein`) installed.