### PR TITLE
fixed npm publishing for NPM

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 


### PR DESCRIPTION
As GPR only supports scoped packages, we have to put `@username` into the `name` property in the `package.json`. This is a scoped package for npm too, which then needs `--access public` to be properly published.

Or what other way do we have to define the package as scoped for GPR?