### PR TITLE
Improve npm publish action

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v1
         with:
           node-version: 10
           registry-url: https://npm.pkg.github.com/

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm publish
+      - if: github.event.ref_type == 'tag'
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
@@ -37,11 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@master
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
           scope: '@your-github-username'
-      - run: npm publish
+      - if: github.event.ref_type == 'tag'
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 10
       - run: npm ci
       - run: npm test
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@master
         with:
-          node-version: 12
+          node-version: 10
           registry-url: https://npm.pkg.github.com/
           scope: '@your-github-username'
       - if: github.event.ref_type == 'tag'


### PR DESCRIPTION
- ~~`setup-node@v1` doesn't support registry auth (GPR etc. needs this), use master branch instead~~
- Limit publish action to tags only (https://github.com/actions/starter-workflows/pull/56#issuecomment-523212856)
- Use current Node LTS version