### PR TITLE
Used absolute path for '/srv/jekyll'

### DIFF
--- a/ci/jekyll.yml
+++ b/ci/jekyll.yml
@@ -13,4 +13,4 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod 777 srv/jekyll && jekyll build --future"
+        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
To avoid error "chmod: srv/jekyll: No such file or directory", see https://github.com/VincentTam/beautiful-jekyll/commit/2d0370a1f93818a8a8e19dc364e8906ee76aedd7/checks#step:3:6.