### PR TITLE
don't want to publish pre-reviewed code

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -1,9 +1,6 @@
 name: Node.js Package
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master


### PR DESCRIPTION
As written, this rule will fire when a PR is opened *against* master.  But that would mean *pre-reviewed code* would be published, which seems incorrect.