### PR TITLE
maven.yml: add `-B` to the maven command line

### DIFF
--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn package --file pom.xml
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Add the `-B` (batch mode) to the `mvn` command line. In interactive mode maven prints many lines of download progress output filling the console output with thousands of useless lines. 

Ideally the github-actions console would interpret `\r' as carriage return (go back to the beginning of the current line and overwrite it). As long as that is not the case using `-B` should be a good enough alternative.