### PR TITLE
add setup-haskell action to haskell starter workflow

### DIFF
--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -9,8 +9,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.6.5'
+        cabal-version: '3.0'
     - name: Install dependencies
-      run: cabal install --only-dependencies --enable-tests
+      run: |
+        cabal update
+        cabal install --only-dependencies --enable-tests
     - name: Build
       run: |
         cabal configure --enable-tests


### PR DESCRIPTION
See #159. This adds https://github.com/actions/setup-haskell to the starter Haskell workflow (otherwise, GHC/Cabal are not installed). It also runs `cabal update` before installing dependencies.