### PR TITLE
Pull Request Labeler: add instructions

### DIFF
--- a/automation/label.yml
+++ b/automation/label.yml
@@ -1,3 +1,10 @@
+# This workflow will triage pull rqeuests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
 name: Labeler
 on: [pull_request]
 


### PR DESCRIPTION
It was pointed out (https://github.com/actions/labeler/issues/18) that when using the labeler from the starter-workflow, it's not clear that there is more work to do to configure the action.  Add information and link to the action's README.