### PR TITLE
Rename "ASP.NET Core" to ".NET Core", add language identifiers.

### DIFF
--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: ASP.NET Core CI
+name: .NET Core
 
 on: [push]
 

--- a/ci/properties/asp.net-core.properties.json
+++ b/ci/properties/asp.net-core.properties.json
@@ -1,6 +1,0 @@
-{
-    "name": "ASP.NET Core",
-    "description": "Build and test an ASP.NET Core project targeting .NET Core.",
-    "iconName": "dotnetcore",
-    "categories": ["ASP", "ASP.NET", ".NET"]
-}

--- a/ci/properties/dotnet-core.properties.json
+++ b/ci/properties/dotnet-core.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": ".NET Core",
+    "description": "Build and test a .NET Core or ASP.NET Core project.",
+    "iconName": "dotnetcore",
+    "categories": ["C#", "F#", "Visual Basic", "ASP", "ASP.NET", ".NET"]
+}


### PR DESCRIPTION
The .NET Core template is not ASP specific.  Change the name to ".NET Core".  Additionally, add language categories matching linguist identifiers so that .NET Core template is recommended.

The following .NET Core projects are not - but should be - using this as the recommended template:

- [ ] https://github.com/ethomson/dogged
- [ ] https://github.com/ethomson/FsPickler
- [ ] https://github.com/ethomson/vb