### PR TITLE
Add Docker push to GitHub Package Registry

### DIFF
--- a/ci/docker-push.yml
+++ b/ci/docker-push.yml
@@ -1,0 +1,73 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: image
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Package Registry.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag image
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/ci/properties/docker-push.properties.json
+++ b/ci/properties/docker-push.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Docker push",
+  "description": "Build, test and push Docker image to GitHub Package Registry.",
+  "iconName": "docker",
+  "categories": ["Dockerfile"]
+}


### PR DESCRIPTION
I'm very excited about Docker support in [GitHub Package Registry](https://help.github.com/en/github/managing-packages-with-github-package-registry/configuring-docker-for-use-with-github-package-registry).

I wanted to create a starter workflow for people already using and familiar with Docker Hub's [automated builds](https://docs.docker.com/docker-hub/builds/) and [automated testing](https://docs.docker.com/docker-hub/builds/automated-testing/) workflow.

This PR replicates 3 of the core behaviors.

1. Run docker compose based test suite. Known as ["Autotest"](https://docs.docker.com/docker-hub/builds/automated-testing/) on Docker Hub.
2. Build and publish `master` to `latest` tag. While `master` is a git convention, `latest` is the default tag that's pulled by default.
3. Also build and publish tags to corresponding names.

Each of these behaviors is easily modified or disabled if someone only wants to publish releases rather than any pushes to `master`.

Would love feedback on some of the naming conventions I used in the workflow.

##

Paired with @myobie
Advice from @mattyoho and @pmarsceill