### PR TITLE
Gradle: Granting execute permission for gradlew

### DIFF
--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -13,5 +13,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
`./gradlew` build fails because it does not have execute permissions. Adding the execute permissions using `chmod` fixes this issue.
See [Android: Granting execute permission for gradlew](https://github.com/actions/starter-workflows/pull/70) for more details