### PR TITLE
Added test as last step to dotnet core template

### DIFF
--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -15,3 +15,5 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build --configuration Release
+    - name: Test with dotnet
+      run: dotnet test --configuration Release  -v n 

--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet
-      run: dotnet test --configuration Release  -v n 
+      run: dotnet test --configuration Release --no-build --no-restore -v n 


### PR DESCRIPTION
Many of the workflows have tests added as a last step, but the dotnet-core workflow is missing that.  This PR adds that last step for the dotnet-core workflow too. 

The test command have the  verbosity set to normal, using the 'v n'.  The default for dotnet test is minimal, but for vstest.console is normal, and in practice normal makes most sense.  
