### PR TITLE
Use separate steps for install, build and test

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -17,11 +17,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: install
-      run: npm install
-    - name: build
-      run: npm run build --if-present
-    - name: test
-      run: npm test
+    - run: npm install
+    - run: npm run build --if-present
+    - run: npm test
       env:
         CI: true

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -17,10 +17,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm ci
-        npm run build --if-present
-        npm test
+    - name: install
+      run: npm install
+    - name: build
+      run: npm run build --if-present
+    - name: test
+      run: npm test
       env:
         CI: true


### PR DESCRIPTION
Having separate steps makes it easier to determine what failed.

Switching from `npm ci` to `npm install` because the Windows image uses node v8.10.0 and npm v5.6.0. `ci` was introduced in npm v5.7.0.

See https://github.com/actions/virtual-environments/issues/88