### PR TITLE
Removed Installation Step from Haskell CI

### DIFF
--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal install --only-dependencies --enable-tests
     - name: Build
       run: |
         cabal configure --enable-tests


### PR DESCRIPTION
Using the provided Haskell Starter workflow didn't work for me, with following error message: 
![image](https://user-images.githubusercontent.com/19567117/69101766-c109bb00-0a60-11ea-9c6f-1a9d24a1972f.png)  from my failing ci in [my project ci](https://github.com/Twonki/Hopinosis/pull/9/checks?check_run_id=308900790)

After removing '--enable-tests' the following error occurred:

![image](https://user-images.githubusercontent.com/19567117/69101873-15149f80-0a61-11ea-9f3b-fead2227dfca.png) [ref to my ci](https://github.com/Twonki/Hopinosis/pull/9/checks?check_run_id=308903115)

The proposed solution runs smoothly for me. 

Maybe the name of the first step should be changed. 
