### PR TITLE
Switch back to `npm ci`

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm run build --if-present
     - run: npm test
       env:


### PR DESCRIPTION
Switch back to using `npm ci`, which is more efficient than `npm install`