### PR TITLE
Use actions/setup-elixir

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -7,11 +7,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: elixir:1.9.1-slim
-
     steps:
     - uses: actions/checkout@v1
+    - name: Setup elixir
+      uses: actions/setup-elixir@v1.0.0
+      with:
+        elixir-version: 1.9.x
+        otp-version: 22.x
     - name: Install Dependencies
       run: |
         mix local.rebar --force

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -12,8 +12,8 @@ jobs:
     - name: Setup elixir
       uses: actions/setup-elixir@v1.0.0
       with:
-        elixir-version: 1.9.x
-        otp-version: 22.x
+        elixir-version: 1.9.x # Define the elixir version [required]
+        otp-version: 22.x # Define the OTP version [required]
     - name: Install Dependencies
       run: |
         mix local.rebar --force

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir
-      uses: actions/setup-elixir@v1.0.0
+      uses: actions/setup-elixir@v1.2.0
       with:
         elixir-version: 1.9.x # Define the elixir version [required]
         otp-version: 22.x # Define the OTP version [required]

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -10,14 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir
-      uses: actions/setup-elixir@v1.2.0
+      uses: actions/setup-elixir@v1
       with:
-        elixir-version: 1.9.x # Define the elixir version [required]
-        otp-version: 22.x # Define the OTP version [required]
+        elixir-version: 1.9.4 # Define the elixir version [required]
+        otp-version: 22.2 # Define the OTP version [required]
     - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
+      run: mix deps.get
     - name: Run Tests
       run: mix test


### PR DESCRIPTION
Now we have a more efficient way to build elixir projects using actions/setup-elixir.

This reduce execution of any build by 10 seconds approximately.

It's important to recommend the use of the actions over docker builds because actions are faster.
