### PR TITLE
Improve PHP workflow and add PHP package workflow

### DIFF
--- a/ci/php-package.yml
+++ b/ci/php-package.yml
@@ -1,0 +1,45 @@
+name: PHP package
+
+on: [push]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:      
+      matrix:
+        php-versions: ['7.1', '7.2', '7.3']
+        os: [ubuntu-latest, windows-latest, macOS-latest]        
+    steps:
+    - uses: actions/checkout@v1
+
+    # Setup PHP environment.
+    # Docs: https://github.com/shivammathur/setup-php/blob/master/README.md    
+    - name: Set up PHP ${{ matrix.php-versions }}
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: ${{ matrix.php-versions }}
+      # extension-csv: mbstring, intl # (optional) specify the extensions you want to enable/install.
+      # ini-values-csv: short_open_tag=On # (optional) specify custom php.ini values.
+      # coverage: xdebug # (optional) specify coverage driver.
+      # pecl: false # (optional) use PECL as fallback to install extensions.
+      
+    - name: Check PHP Version
+      run: php -v
+
+    - name: Check Composer Version
+      run: composer -V
+
+    - name: Check PHP Extensions
+      run: php -m
+      
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+    # - name: Run test suite
+    #   run: composer run-script test

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -9,6 +9,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    
+    # Setup PHP environment.
+    # Docs: https://github.com/shivammathur/setup-php/blob/master/README.md
+    - name: Setup PHP
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: '7.3'
+      # extension-csv: mbstring, intl # (optional) specify the extensions you want to enable/install.
+      # ini-values-csv: short_open_tag=On # (optional) specify custom php.ini values.
+      # coverage: xdebug # (optional) specify coverage driver.
+      # pecl: false # (optional) use PECL as fallback to install extensions.
 
     - name: Validate composer.json and composer.lock
       run: composer validate


### PR DESCRIPTION
- Improve PHP workflow to add support for installing extensions as most PHP projects have extensions which are not default as requirements.
- Add a PHP package workflow to test PHP packages with different versions and supported OS.

I know you do not accept external actions here, but I have used [shivammathur/setup-php](https://github.com/shivammathur/setup-php) in both these workflows as PHP does not have one tool to install extensions for all OS and it is difficult to maintain a workflow for different OS if one has to script to install extensions and keep track of them. 

- [ ] Does not use an Action that isn't in the `actions` organization. Please See #221 
- [x] Does not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Does not use a paid service or product.

Fixes #221 