### PR TITLE
GitHub Package Registry is now GitHub Packages

### DIFF
--- a/ci/properties/npm-publish.properties.json
+++ b/ci/properties/npm-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Node.js Package",
-    "description": "Publishes a Node.js package to npm and GitHub Package Registry.",
+    "description": "Publishes a Node.js package to npm and GitHub Packages.",
     "iconName": "node-package-transparent",
     "categories": ["JavaScript", "SDLC"]
 }


### PR DESCRIPTION
Quick name change to update a reference to "GitHub Package Registry" to "GitHub Packages".