### PR TITLE
Remove max-parallel

### DIFF
--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -7,7 +7,6 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 


### PR DESCRIPTION
We're using this template for the new language guide for Python and @brcrista [mentioned](https://github.com/github/help-docs/pull/11924/files#r360389597) max-parallel option might a carryover from Azure. I think there are only 5 jobs that will get kicked off, so it's a little redundant and I haven't noticed other CI templates using max-parallel.
