### PR TITLE
Use product name

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Node.js CI
 
 on: [push]
 


### PR DESCRIPTION
I'm [writing a guide](https://github.com/github/help-docs/pull/) for using Node.js with GitHub Actions and GitHub Packages, and I'm trying to consistently refer to node as "Node.js." I'm also trying to ensure I match the templates in the starter-workflows repo. 

Any objection to using the full product name here?