### PR TITLE
docker-push workflow: tag image with $IMAGE_NAME environment variable

### DIFF
--- a/ci/docker-push.yml
+++ b/ci/docker-push.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
Proposing tagging the Docker image built here using the `$IMAGE_NAME` environment variable set earlier in the workflow, instead of just `image`!