### PR TITLE
Revert "Don't use actions/checkout@master"

### DIFF
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:

--- a/ci/google.yml
+++ b/ci/google.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@master
 
     # Setup gcloud CLI
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master


### PR DESCRIPTION
Reverts actions/starter-workflows#240
@myobie @christeredvartsen @cdb #289 #288 #287 #253     - name: Deployci/google.ymlFrom 3cd5fe49e61bbfa7a4b0fa3fea2984c0e46306c0 Mon Sep 17 00:00:00 2001
From: Chris Sidi <hashtagchris@github.com>
Date: Tue, 3 Dec 2019 19:20:23 -0500
Subject: [PATCH] Don't use actions/checkout@master

See https://github.com/actions/toolkit/blob/master/docs/action-versioning.md
---
 ci/azure.yml    | 2 +-
 ci/gem-push.yml | 2 +-
 ci/google.yml   | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)

diff --git a/ci/azure.yml b/ci/azure.yml
index f3683d6..5899aa3 100644
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
diff --git a/ci/gem-push.yml b/ci/gem-push.yml
index ff0bfb3..f5fb3b6 100644
--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
diff --git a/ci/google.yml b/ci/google.yml
index 4f23b12..69d6781 100644
--- a/ci/google.yml
+++ b/ci/google.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
 
     # Setup gcloud CLI
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master