### PR TITLE
Remove hardcoded values from google.yml

### DIFF
--- a/ci/google.yml
+++ b/ci/google.yml
@@ -6,7 +6,7 @@
 #
 # 2. Set up secrets in your workspace: GKE_PROJECT with the name of the project, GKE_EMAIL with the service account email, GKE_KEY with the Base64 encoded JSON service account key (https://github.com/GoogleCloudPlatform/github-actions/tree/docs/service-account-key/setup-gcloud#inputs).
 #
-# 3. Change the values for the GKE_ZONE, GKE_CLUSTER and IMAGE environment variables (below).
+# 3. Change the values for the GKE_ZONE, GKE_CLUSTER, IMAGE, REGISTRY_HOSTNAME and DEPLOYMENT_NAME environment variables (below).
 
 name: Build and Deploy to GKE
 
@@ -23,6 +23,8 @@ env:
   GKE_ZONE: us-west1-a
   GKE_CLUSTER: example-gke-cluster
   IMAGE: gke-test
+  REGISTRY_HOSTNAME: gcr.io
+  DEPLOYMENT_NAME: gke-test
 
 jobs:
   setup-build-publish-deploy:
@@ -49,14 +51,14 @@ jobs:
     # Build the Docker image
     - name: Build
       run: |        
-        docker build -t gcr.io/"$GKE_PROJECT"/"$IMAGE":"$GITHUB_SHA" \
+        docker build -t "$REGISTRY_HOSTNAME"/"$GKE_PROJECT"/"$IMAGE":"$GITHUB_SHA" \
           --build-arg GITHUB_SHA="$GITHUB_SHA" \
           --build-arg GITHUB_REF="$GITHUB_REF" .
 
     # Push the Docker image to Google Container Registry
     - name: Publish
       run: |
-        docker push gcr.io/$GKE_PROJECT/$IMAGE:$GITHUB_SHA
+        docker push $REGISTRY_HOSTNAME/$GKE_PROJECT/$IMAGE:$GITHUB_SHA
         
     # Set up kustomize
     - name: Set up Kustomize
@@ -68,7 +70,7 @@ jobs:
     - name: Deploy
       run: |
         gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-        ./kustomize edit set image gcr.io/$GKE_PROJECT/$IMAGE:${GITHUB_SHA}
+        ./kustomize edit set image $REGISTRY_HOSTNAME/$GKE_PROJECT/$IMAGE:${GITHUB_SHA}
         ./kustomize build . | kubectl apply -f -
-        kubectl rollout status deployment/gke-test
+        kubectl rollout status deployment/$DEPLOYMENT_NAME
         kubectl get services -o wide


### PR DESCRIPTION
The google.yml deployment workflow starter hardcoded the registry hostname as `gcr.io` even though there are other possible registry hostnames. It also hardcoded the deployment name. This puts them in env variables and adds to the comments that they need to be adjusted by the user.
