### PR TITLE
Remove End-of-Life Node.js 8.x

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 8 went End-of-Life at the end of 2019 (https://github.com/nodejs/Release) and should not be used in new workflows.
