### PR TITLE
add Cypress starter workflow

### DIFF
--- a/ci/cypress.yml
+++ b/ci/cypress.yml
@@ -1,0 +1,45 @@
+name: Cypress
+
+on: [push]
+
+env:
+  CI: 1 # minimal progress output
+  TERM: xterm # good terminal rendering
+
+jobs:
+  e2e:
+    name: Cypress tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache NPM modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
+    - name: Cache Cypress binary
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/Cypress
+        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-cypress-
+    - name: install Cypress
+      run: |
+        npm ci
+        npx cypress verify
+    - name: E2E tests
+      run: npx cypress run
+    # save any error screenshots as test artifacts
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: screenshots
+        path: cypress/screenshots
+    # video should always be generated
+    - uses: actions/upload-artifact@v1
+      with:
+        name: videos
+        path: cypress/videos

--- a/ci/properties/cypress.properties.json
+++ b/ci/properties/cypress.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Cypress",
+  "description": "Run end-to-end web application tests using Cypress.io",
+  "iconName": "cypress",
+  "categories": ["Testing", "Cypress"]
+}

--- a/icons/cypress.svg
+++ b/icons/cypress.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" style="enable-background:new 0 0 72 72;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#4A4A4D;stroke:#FFFFFF;stroke-miterlimit:10;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+</style>
+<path class="st0" d="M35.5,9C50.7,9,63,21.3,63,36.5S50.7,64,35.5,64C20.3,64,8,51.7,8,36.5S20.3,9,35.5,9L35.5,9z"/>
+<path class="st1" d="M50.1,48.6c-1,3.1-2.5,5.4-4.6,7.1c-2.1,1.7-4.9,2.6-8.4,2.9l-0.7-4.6c2.3-0.3,4-0.8,5.1-1.6
+	c0.4-0.3,1.2-1.2,1.2-1.2l0,0l-8.3-26.6h6.9l4.8,19.9l5.1-19.9h6.7L50.1,48.6L50.1,48.6z"/>
+<path class="st1" d="M26,23.7c1.6,0,3.1,0.2,4.3,0.7c1.3,0.5,2.5,1.2,3.7,2.2l-2.8,3.8c-0.8-0.6-1.6-1-2.3-1.3
+	c-0.7-0.3-1.6-0.4-2.4-0.4c-3.4,0-5.1,2.6-5.1,7.9c0,2.7,0.4,4.6,1.3,5.7c0.9,1.2,2.1,1.7,3.8,1.7c0.8,0,1.6-0.1,2.3-0.4
+	c0.7-0.3,1.5-0.7,2.5-1.3l2.8,4c-2.3,1.9-4.9,2.8-7.9,2.8c-2.4,0-4.4-0.5-6.2-1.5c-1.7-1-3.1-2.5-4-4.4c-0.9-1.9-1.4-4.1-1.4-6.7
+	c0-2.5,0.5-4.8,1.4-6.7c0.9-2,2.3-3.5,4-4.6C21.7,24.3,23.7,23.7,26,23.7L26,23.7z"/>
+</svg>
+<!-- source https://github.com/cypress-io/cypress-icons -->


### PR DESCRIPTION
Hi,

I would like to add a starter workflow for anyone running end-to-end browser tests using open source test runner [Cypress.io](https://github.com/cypress-io/cypress). The test runner is gaining in popularity quickly, is loved by users (see https://2019.stateofjs.com/testing/) and has non-trivial setup (caching of 2 folders). This starter workflow helps a lot, I think. For anything more complicated, the users can edit this workflow file, or use our [cypress-io/github-action](https://github.com/cypress-io/github-action)

**Idea 💡:** what if you allow using non `actions/` actions, then the starter workflow could be [minimal](https://github.com/cypress-io/github-action#basic)

---
Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request:

- [x] Include a good description of the workflow.
- [x] Links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [x] Includes a matching `ci/properties/*.properties.json` file.
- [X] Use title case for the names of workflows and steps, for example "Run tests".
- [x] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] CI workflows should run `push`.


Some general notes:

- [x] Does not use an Action that isn't in the `actions` organization.
- [x] Does not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Does not use a paid service or product.
