### PR TITLE
Remove Python 2.7 from default tests

### DIFF
--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 2 is deprecated: https://www.python.org/doc/sunset-python-2/
