### PR TITLE
Updating .NET Core SDK version to LTS

### DIFF
--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -12,6 +12,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 3.1.101
     - name: Build with dotnet
       run: dotnet build --configuration Release


### PR DESCRIPTION
2.2 is no longer supported, so moving to latest SDK released for .NET core which supports and encourages LTS runtime version as well as down-level building.