### PR TITLE
Fix macOS virtual machine case in Swift workflow

### DIFF
--- a/ci/swift.yml
+++ b/ci/swift.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
When creating new workflow using Swift, the macOS name is not lowercase. The editor tells you the value is invalid. See for yourself on the following screenshot:

![Screenshot 2020-01-30 at 14 48 11](https://user-images.githubusercontent.com/708312/73455501-7e256700-4370-11ea-83fd-eed0d1d5137d.png)

I propose making the virtual machine lowercase so people do not get this warning during Swift package setup.