### PR TITLE
Add Hakyll starter workflow

### DIFF
--- a/ci/hakyll.yml
+++ b/ci/hakyll.yml
@@ -1,0 +1,72 @@
+name: Hakyll site CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: [ '8.6.5' ]
+        cabal: [ '3.0' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+    - name: Cache ~/.cabal/store
+      uses: actions/cache@v1
+      with:
+        path: ~/.cabal/store
+        key: cabal-store-${{ runner.OS }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: |
+          cabal-store-${{ runner.OS }}-${{ matrix.ghc }}-
+          cabal-store-${{ runner.OS }}-
+    - name: Cache dist-newstyle
+      uses: actions/cache@v1
+      with:
+        path: dist-newstyle
+        key: dist-newstyle-${{ runner.OS }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: |
+          dist-newstyle-${{ runner.OS }}-${{ matrix.ghc }}-
+          dist-newstyle-${{ runner.OS }}-
+    - name: Update the package list
+      run: |
+        cabal update
+    - name: Build dependencies and the site generator
+      run: |
+        cabal build --constraint "hakyll -previewServer -watchServer"
+        # Uncomment the following if external link check is not required.
+        # cabal build --constraint "hakyll -previewServer -watchServer -checkExternal"
+    - name: Build the site
+      env:
+        # citeproc requires the locale environment variable.
+        LANG: en_US.UTF-8
+      run: |
+        cabal exec -- site build
+    - name: Check the site output
+      run: |
+        cabal exec -- site check
+    - uses: peaceiris/actions-gh-pages@v2.10.1
+      env:
+        # Type the following in the terminal to get private/public keys:
+        #
+        # ssh-keygen -t rsa -b 4096 -C "$(git config user.email)" -f gh-pages -N ""
+        #
+        # and add them to the GitHub repo. For details, see
+        # https://github.com/marketplace/actions/github-pages-action
+        #
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+
+        # Ensure to match the source branch specified on the GitHub setting.
+        #
+        PUBLISH_BRANCH: master
+        PUBLISH_DIR: _site
+        if: github.ref == 'refs/heads/source'
+        # Rename `source` to the branch for the source code
+        # if: github.ref == 'refs/heads/master'
+      with:
+        emptyCommits: false

--- a/ci/properties/hakyll.properties.json
+++ b/ci/properties/hakyll.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Hakyll",
+    "description": "Package and deploy a Hakyll site using ghc and cabal.",
+    "iconName": "haskell",
+    "categories": ["HTML", "Haskell"]
+}


### PR DESCRIPTION
Description: [Hakyll](https://hackage.haskell.org/package/hakyll) is a popular static site generator among Haskell programmers and alike. It is similar to Jekyll but implemented in Haskell. It supports [Pandoc](https://pandoc.org) which is a powerful document converter, so a variety of document formats are supported including, of course, Markdown.

---------------------------------------------
Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request:

- [X] Include a good description of the workflow.
- [X] Links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [X] Includes a matching `ci/properties/*.properties.json` file.
- [X] Use title case for the names of workflows and steps, for example "Run tests".
- [X] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [X] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [X] CI workflows should run `push`.
- [X] Packaging workflows should run on `release` with `types: [created]`.

Some general notes:

- [X] Does not use an Action that isn't in the `actions` organization.
- [X] Does not send data to any 3rd party service except for the purposes of installing dependencies.
- [X] Does not use a paid service or product.
