### PR TITLE
ci/haskell.yml: properly build dependencies, tests and benchmarks

### DIFF
--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -17,6 +17,19 @@ jobs:
       with:
         ghc-version: '8.8.2'
         cabal-version: '3.0'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
     - name: Install dependencies
       run: |
         cabal update

--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -20,10 +20,8 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal install --only-dependencies --enable-tests
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
-      run: |
-        cabal configure --enable-tests
-        cabal build
+      run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test
+      run: cabal test all


### PR DESCRIPTION
Using `cabal install` to install dependency doesn't work at all, because it is a command for installing executables. Updated to use `cabal build`, and made sure that tests and benchmarks will be built.