### PR TITLE
Docker image workflow - tag image with repository name

### DIFF
--- a/ci/docker-image.yml
+++ b/ci/docker-image.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file Dockerfile --tag ${{ github.repository }}:$(date +%s)


### PR DESCRIPTION
# Summary

Proposing a quick change to the `docker-image.yml` workflow - tagging the image with the repository's name, instead of `my-image-name`. Might as well, right?

Alternatively, could tag images the same way the `docker-push.yml` workflow does, with an `env` - https://github.com/actions/starter-workflows/blob/e5a3a0e11268f84ad0ff6569a47e197cc8e1f758/ci/docker-push.yml#L16-L18