### PR TITLE
Add --locked flag for rust action

### DIFF
--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --locked --verbose


### PR DESCRIPTION
Include --locked flag to the rust action to make it the build reproducible. 