### PR TITLE
Update Starter Workflows

### DIFF
--- a/ci/android.yml
+++ b/ci/android.yml
@@ -1,6 +1,10 @@
 name: Android CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/ant.yml
+++ b/ci/ant.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/ant.yml
+++ b/ci/ant.yml
@@ -1,3 +1,6 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-ant
+
 name: Java CI
 
 on:

--- a/ci/aws.yml
+++ b/ci/aws.yml
@@ -1,5 +1,5 @@
 # This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, whenever a release is created
+# and then will deploy a new task definition to Amazon ECS, when a release is created
 #
 # To use this workflow, you will need to complete the following set-up steps:
 #

--- a/ci/aws.yml
+++ b/ci/aws.yml
@@ -1,6 +1,5 @@
 # This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, on every push
-# to the master branch.
+# and then will deploy a new task definition to Amazon ECS, whenever a release is created
 #
 # To use this workflow, you will need to complete the following set-up steps:
 #
@@ -25,9 +24,8 @@
 #    and best practices on handling the access key credentials.
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created]
 
 name: Deploy to Amazon ECS
 

--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -1,4 +1,4 @@
-# This workflow will build and push a node.js application to an Azure Web App on every push to the master branch.
+# This workflow will build and push a node.js application to an Azure Web App whenever a release is created.
 #
 # To configure this workflow:
 #
@@ -9,9 +9,8 @@
 # For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created]
 
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name

--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -1,4 +1,4 @@
-# This workflow will build and push a node.js application to an Azure Web App whenever a release is created.
+# This workflow will build and push a node.js application to an Azure Web App when a release is created.
 #
 # To configure this workflow:
 #

--- a/ci/blank.yml
+++ b/ci/blank.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/blank.yml
+++ b/ci/blank.yml
@@ -1,20 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
 name: CI
 
+# Controls when the action will run. Triggers the workflow on push or pull request 
+# events but only for the master branch
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # This workflow contains a single job called "build"
   build:
-
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
     - name: Run a one-line script
       run: echo Hello, world!
+
+    # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
         echo Add other actions to build,

--- a/ci/c-cpp.yml
+++ b/ci/c-cpp.yml
@@ -1,6 +1,10 @@
 name: C/C++ CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/clojure.yml
+++ b/ci/clojure.yml
@@ -1,6 +1,10 @@
 name: Clojure CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/crystal.yml
+++ b/ci/crystal.yml
@@ -1,6 +1,10 @@
 name: Crystal CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -1,6 +1,10 @@
 name: Dart CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/django.yml
+++ b/ci/django.yml
@@ -1,6 +1,10 @@
 name: Django CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/docker-image.yml
+++ b/ci/docker-image.yml
@@ -1,6 +1,10 @@
 name: Docker Image CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
 

--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
             docker build . --file Dockerfile
           fi
 
-  # Push image to GitHub Package Registry.
+  # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     # Ensure test job passes before pushing image.

--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -1,6 +1,10 @@
 name: .NET Core
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -1,6 +1,10 @@
 name: Elixir CI
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/erlang.yml
+++ b/ci/erlang.yml
@@ -1,6 +1,10 @@
 name: Erlang CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
 

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -1,12 +1,10 @@
 name: Ruby Gem
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/go.yml
+++ b/ci/go.yml
@@ -1,5 +1,11 @@
 name: Go
-on: [push]
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 jobs:
 
   build:

--- a/ci/google.yml
+++ b/ci/google.yml
@@ -1,4 +1,4 @@
-# This workflow will build a docker container, publish it to Google Container Registry, and deploy it to GKE whenever a release is created
+# This workflow will build a docker container, publish it to Google Container Registry, and deploy it to GKE when a release is created
 #
 # To configure this workflow:
 #

--- a/ci/google.yml
+++ b/ci/google.yml
@@ -1,4 +1,4 @@
-# This workflow will build a docker container, publish it to Google Container Registry, and deploy it to GKE.
+# This workflow will build a docker container, publish it to Google Container Registry, and deploy it to GKE whenever a release is created
 #
 # To configure this workflow:
 #
@@ -11,9 +11,8 @@
 name: Build and Deploy to GKE
 
 on:
-  push:
-    branches:
-    - master
+  release:
+    types: [created]
 
 # Environment variables available to all jobs and steps in this workflow
 env:

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -21,10 +21,11 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Build with Gradle
+      run: gradle build
 
-    - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+    - name: Publish to GitHub Packages
+      run: gradle publish
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        USERNAME: ${{ github.actor }}
+        PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will build a package using gradle and then publish it to GitHub packages whenever a release is created
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java#publishing-using-gradle
 
 name: Gradle Package

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will build a package using gradle and then publish it to GitHub packages whenever a release is created
+# For more information see: https://github.com/actions/setup-java#publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Build with Gradle
       run: gradle build
 
+    # The USERNAME and PASSWORD need to correspond to the credentials environment variables used in
+    # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
       run: gradle publish
       env:

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -1,4 +1,7 @@
-name: Java CI
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
 
 on:
   push:

--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -1,6 +1,10 @@
 name: Haskell CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/jekyll.yml
+++ b/ci/jekyll.yml
@@ -1,6 +1,10 @@
 name: Jekyll site CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/laravel.yml
+++ b/ci/laravel.yml
@@ -1,6 +1,10 @@
 name: Laravel
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   laravel-tests:

--- a/ci/laravel.yml
+++ b/ci/laravel.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   laravel-tests:
+
     runs-on: ubuntu-latest
+    
     steps:
     - uses: actions/checkout@v2
     - name: Copy .env

--- a/ci/maven-publish.yml
+++ b/ci/maven-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages whenever a release is created
+# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/ci/maven-publish.yml
+++ b/ci/maven-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages whenever a release is created
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
 
 name: Maven Package

--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -1,4 +1,7 @@
-name: Java CI
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
 
 on:
   push:

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -1,3 +1,6 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
 name: Node.js CI
 
 on:

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -1,6 +1,10 @@
 name: Node.js CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -1,3 +1,6 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
 name: Node.js Package
 
 on:

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -1,6 +1,10 @@
 name: PHP Composer
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/properties/docker-publish.properties.json
+++ b/ci/properties/docker-publish.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Publish Docker Container",
+  "description": "Build, test and push Docker image to GitHub Packages.",
+  "iconName": "docker",
+  "categories": ["Dockerfile"]
+}

--- a/ci/properties/docker-push.properties.json
+++ b/ci/properties/docker-push.properties.json
@@ -1,6 +1,0 @@
-{
-  "name": "Docker push",
-  "description": "Build, test and push Docker image to GitHub Package Registry.",
-  "iconName": "docker",
-  "categories": ["Dockerfile"]
-}

--- a/ci/properties/gradle-publish.properties.json
+++ b/ci/properties/gradle-publish.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Publish Java Package with Gradle",
+    "description": "Build a Java Package using Gradle and publish it to GitHub Packages.",
+    "iconName": "gradle",
+    "categories": ["Java", "Gradle"]
+}

--- a/ci/properties/gradle-publish.properties.json
+++ b/ci/properties/gradle-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Publish Java Package with Gradle",
-    "description": "Build a Java Package using Gradle and publish it to GitHub Packages.",
+    "description": "Build a Java Package using Gradle and publish to GitHub Packages.",
     "iconName": "gradle",
     "categories": ["Java", "Gradle"]
 }

--- a/ci/properties/gradle.properties.json
+++ b/ci/properties/gradle.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Gradle",
+    "name": "Java with Gradle",
     "description": "Build and test a Java project using a Gradle wrapper script.",
     "iconName": "gradle",
     "categories": ["Java", "Gradle"]

--- a/ci/properties/maven-publish.properties.json
+++ b/ci/properties/maven-publish.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Publish Java Package with Maven",
+    "description": "Build a Java Package using Maven and publish it to GitHub Packages.",
+    "iconName": "maven",
+    "categories": ["Java", "Maven"]
+}

--- a/ci/properties/maven-publish.properties.json
+++ b/ci/properties/maven-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Publish Java Package with Maven",
-    "description": "Build a Java Package using Maven and publish it to GitHub Packages.",
+    "description": "Build a Java Package using Maven and publish to GitHub Packages.",
     "iconName": "maven",
     "categories": ["Java", "Maven"]
 }

--- a/ci/properties/maven.properties.json
+++ b/ci/properties/maven.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Maven",
+    "name": "Java with Maven",
     "description": "Build and test a Java project with Apache Maven.",
     "iconName": "maven",
     "categories": ["Java", "Maven"]

--- a/ci/properties/npm-publish.properties.json
+++ b/ci/properties/npm-publish.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Node.js Package",
+    "name": "Publish Node.js Package",
     "description": "Publishes a Node.js package to npm and GitHub Packages.",
     "iconName": "node-package-transparent",
     "categories": ["JavaScript", "SDLC"]

--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -1,3 +1,6 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
 name: Python application
 
 on:

--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -1,6 +1,10 @@
 name: Python application
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -1,3 +1,6 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
 name: Python package
 
 on:
@@ -5,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+
 jobs:
   build:
 

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -1,7 +1,10 @@
 name: Python package
 
-on: [push]
-
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
 

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -1,3 +1,6 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
 name: Upload Python Package
 
 on:

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   deploy:
+
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -1,6 +1,10 @@
 name: Ruby
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/scala.yml
+++ b/ci/scala.yml
@@ -1,6 +1,10 @@
 name: Scala CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/ci/swift.yml
+++ b/ci/swift.yml
@@ -1,6 +1,10 @@
 name: Swift
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION

Miscellaneous improvements specified in the following issue: https://github.com/github/c2c-actions/issues/611

**New Workflows**
New workflows for `Publish Java Package with Maven` and `Publish Java Package with Gradle`. The YAML comes from the `setup-java` action that already had these examples in the README: https://github.com/actions/setup-java#setup-java

**Documentation**
Added Links to guides for workflows that have documentation: https://help.github.com/en/actions/language-and-framework-guides
This includes
- Python
- Javascript (Node)
- Java (Maven, Ant & Gradle)

**Comments**
Added lots of inline comments to the basic YAML template. This will help first time actions users understand what is going on. I didn't add comments to other workflows since the name of the step is usually self-explanatory in terms of what is being run

**Triggers**
Updated triggers to work with PR events and added branch filters. Workflow events that publish some package or do a deployment have been updated to only trigger on a release

**GitHub Packages**
Changes a few references from `GitHub Package Registry` to `GitHub Packages`

A few other minor adjustments and renames for consistency