### PR TITLE
Revert "Add missing categories"

### DIFF
--- a/ci/properties/aws.properties.json
+++ b/ci/properties/aws.properties.json
@@ -2,5 +2,5 @@
     "name": "Deploy to Amazon ECS",
     "description": "Deploy a container to an Amazon ECS service powered by AWS Fargate or Amazon EC2.",
     "iconName": "aws",
-    "categories": ["Dockerfile"]
+    "categories": null
 }

--- a/ci/properties/azure.properties.json
+++ b/ci/properties/azure.properties.json
@@ -2,5 +2,5 @@
     "name": "Deploy Node.js to Azure Web App",
     "description": "Build a Node.js project and deploy it to an Azure Web App.",
     "iconName": "azure",
-    "categories": ["JavaScript"]
+    "categories": null
 }

--- a/ci/properties/google.properties.json
+++ b/ci/properties/google.properties.json
@@ -2,5 +2,5 @@
     "name": "Build and Deploy to GKE",
     "description": "Build a docker container, publish it to Google Container Registry, and deploy to GKE.",
     "iconName": "googlegke",
-    "categories": ["Dockerfile"]
+    "categories": null
 }


### PR DESCRIPTION
Reverts actions/starter-workflows#347

There were some issues with Azure becoming recommended for all workflows while the other partern worklflows are not, this behavior is not desired. Verified this locally
![image](https://user-images.githubusercontent.com/16109154/75794829-a0e0dc00-5d71-11ea-83a9-51a6e12c7f93.png)

Original thread where this was discussed: https://github.slack.com/archives/CMUS9J5K9/p1582047037027300?thread_ts=1582046679.021400&cid=CMUS9J5K9

See also: https://github.com/github/github/pull/136656#discussion_r385404724
