### PR TITLE
Swift: Checking out private dependencies

### DIFF
--- a/ci/swift.yml
+++ b/ci/swift.yml
@@ -13,7 +13,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    # Use alternative GitHub PAT for checking out private Swift Package Manager dependencies.
+    # - name: Checkout private dependencies
+    #   run: |
+    #     auth_header="AUTHORIZATION: basic $(echo -n x-access-token:$AUTH_TOKEN | base64)"
+    #     git config --global http.https://github.com/.extraheader "$auth_header"
+    #     swift package resolve
+    #     git config --global --unset http.https://github.com/.extraheader
+    #   env:
+    #     AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+
     - name: Build
       run: swift build -v
+
     - name: Run tests
       run: swift test -v


### PR DESCRIPTION
Working with private dependencies is a little tricky on GitHub Actions because of how it interacts with `actions/checkout` . I'm hoping that introducing an example step can help those trying to use GitHub Actions with private dependencies on github.com or GHE use-cases.

The introduced step is commented out rather than included by default. Users will need to manually set up a PAT and set a Secret. And projects that only relay on public dependencies can safely skip this step.

This step works similar to [how `actions/checkout` suggests working with submodules](https://github.com/actions/checkout#checkout-submodules).