### PR TITLE
Update docker-publish.yml

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -55,7 +55,8 @@ jobs:
 
       - name: Push image
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Convert to lowercase
+          IMAGE_ID=$(echo "docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME" | sed -e 's/\(.*\)/\L\1/')
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')


### PR DESCRIPTION
Convert IMAGE_ID to lowercase due to the limit of Github.

This will fix:

- When repository or username contains uppercase letters, publish action will get an error.