### PR TITLE
Switch back to `npm ci`

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm run build --if-present
     - run: npm test
       env:


### PR DESCRIPTION
Switch back to using `npm ci`, which is more efficient than `npm install`

Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request:

- [ ✔] Include a good description of the workflow.
- [✔ ] Links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [ ✔] Includes a matching `ci/properties/*.properties.json` file.
- [✔ ] Use title case for the names of workflows and steps, for example "Run tests".
- [ ✔] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [✔ ] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [✔ ] CI workflows should run `push`.
- [ ✔] Packaging workflows should run on `release` with `types: [created]`.

Some general notes:

- [ ✔] Does not use an Action that isn't in the `actions` organization.
- [ ✔] Does not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ✔] Does not use a paid service or product.
