### PR TITLE
Inconsistent environmental variable name

### DIFF
--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Build with Gradle
       run: gradle build
 
-    # The USERNAME and PASSWORD need to correspond to the credentials environment variables used in
+    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
       run: gradle publish
       env:
         USERNAME: ${{ github.actor }}
-        PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-gradle-for-use-with-github-packages

In the example above, the Gradle code tries to get the token value from the `TOKEN`, yet this workflow saves the token in the `PASSWORD`.

Easy fix yet can save lots of time for newcomers.