### PR TITLE
Bug fix :  repository name must be lowercase

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Push image
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')


### PR DESCRIPTION
https://github.com/Licsber/opencv-docker/runs/514244582?check_suite_focus=true

 Push image: 
Error parsing reference: "docker.pkg.github.com/Licsber/opencv-docker/opencv:latest" is not a valid repository/tag: invalid reference format: repository name must be lowercase


My username contains uppercase characters, this make push failed.
So fix the bug by change all uppercase in IMAGE_ID to lowercase.
