### PR TITLE
npm-publish: remove explicit scope

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
-          scope: '@your-github-username'
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
The setup-node action will default the scope to the correct user (the repo owner), so we do not need to explicitly include it in the workflow.  Removing it ensures that the starter template is easier for people to use; now there are no changes necessary to get started.  https://github.com/actions/setup-node/blob/master/src/authutil.ts#L26