### PR TITLE
Adds App Service documentation references

### DIFF
--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -1,8 +1,12 @@
 # This workflow will build and push a node.js application to an Azure Web App when a release is created.
 #
+# This workflow assumes you have already created the target Azure App Service web app.
+# For instructions see https://docs.microsoft.com/azure/app-service/app-service-plan-manage#create-an-app-service-plan
+#
 # To configure this workflow:
 #
 # 1. Set up a secret in your repository named AZURE_WEBAPP_PUBLISH_PROFILE with the value of your Azure publish profile.
+#    For instructions on obtaining the publish profile see: https://docs.microsoft.com/azure/app-service/deploy-github-actions#configure-the-github-secret
 #
 # 2. Change the values for the AZURE_WEBAPP_NAME, AZURE_WEBAPP_PACKAGE_PATH and NODE_VERSION environment variables  (below).
 #


### PR DESCRIPTION
This workflow assumes an App Service web app has already been created and that a user knows how to obtain the desired input values. This cannot be assumed. Therefore I have included references to the relevant documentation.

Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request:

- [x] Include a good description of the workflow.
- [x] Links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [ ] Includes a matching `ci/properties/*.properties.json` file.
- [ ] Use title case for the names of workflows and steps, for example "Run tests".
- [ ] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [ ] CI workflows should run `push`.
- [ ] Packaging workflows should run on `release` with `types: [created]`.

Some general notes:

- [ ] Does not use an Action that isn't in the `actions` organization.
- [ ] Does not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Does not use a paid service or product.
