### PR TITLE
Add starter workflow for ruby/setup-ruby

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -21,7 +21,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
         ruby-version: 2.6
     - name: Install dependencies

--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -1,3 +1,10 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
 name: Ruby
 
 on:
@@ -7,18 +14,17 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
This PR adds a starter workflow for [ruby/setup-ruby](https://github.com/ruby/setup-ruby), the most complete action to setup Ruby. This action is hosted in the official GitHub Ruby organization.

I'm doing this PR based on this comment by @ethomson : https://github.com/actions/setup-ruby/pull/49#issuecomment-607416625

- [x] Include a good description of the workflow.
- [x] Links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [x] Includes a matching `ci/properties/*.properties.json` file.
- [x] Use title case for the names of workflows and steps, for example "Run tests".
- The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")

Should it just be `Ruby` here?
But then we would have two starter workflows with the title `Ruby` which seems confusing.

I followed a similar structure to `ci/node.js.yml`, and used the `matrix` form to show how to test on multiple Rubies, including alternative implementations, which [actions/setup-ruby](https://github.com/actions/setup-ruby) cannot do currently.

- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
I think the commands are obvious and need no comment.
- [x] CI workflows should run `push`.

Some general notes:

- Does not use an Action that isn't in the `actions` organization.

Since it was suggested in https://github.com/actions/setup-ruby/pull/49#issuecomment-607416625 this was OK, I suppose it doesn't apply anymore.
- [x] Does not send data to any 3rd party service except for the purposes of installing dependencies.
The action only downloads prebuilt Ruby hosted as GitHub Releases.
- [x] Does not use a paid service or product.