### PR TITLE
Use cache for sbt and coursier

### DIFF
--- a/ci/scala.yml
+++ b/ci/scala.yml
@@ -17,5 +17,15 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Cache sbt
+      uses: actions/cache@v1
+      with:
+        path: .sbt/boot
+        key: cache-sbt-${{ hashFiles('project/build.properties') }}
+    - name: Cache coursier
+      uses: actions/cache@v1
+      with:
+        path: .coursier/cache
+        key: cache-coursier-${{ hashFiles('build.sbt') }}
     - name: Run tests
-      run: sbt test
+      run: sbt -Dsbt.boot.directory=.sbt/boot -Dsbt.coursier.home=.coursier test


### PR DESCRIPTION
By caching sbt boot and coursier directories, sbt will not download itself and project dependencies anytime a new job is launched.

You can see caching in action on [this repository](https://github.com/seblm/hexagonal/actions).