### PR TITLE
update setup-go to v2

### DIFF
--- a/ci/go.yml
+++ b/ci/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ^1.13
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
setup-go released a v2 recently after being in v2-beta for quite awhile with customer validation.

There are many unit and e2e workflows validating it (along with customer validation).

Here's an example workflow of mine validating it.

https://github.com/bryanmacfarlane/actions-playground/runs/593761737?check_suite_focus=true

I also update it with a `^` which setup-go supports to ensure as 1.14, 1.15 etc are released, we don't have to keep updating the starter workflow.  go will maintain compat across 1.x