### PR TITLE
node: remove CI=true environment variable

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -27,5 +27,3 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-      env:
-        CI: true


### PR DESCRIPTION
The CI environment variable is now [set by GitHub Actions directly](https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/).  No need to set it in the workflow.