### PR TITLE
PHP: Remove deprectated composer --no-suggest

### DIFF
--- a/ci/php.yml
+++ b/ci/php.yml
@@ -18,7 +18,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md


### PR DESCRIPTION
Composer, PHP dependency manager is about to release version 2. It deprecates the `--no-suggest` flag because the output is now truncated to prevent spamming suggestions. Using `--no-suggest` raises a deprecation notice now:

Please see for changes in Composer v2: https://php.watch/articles/composer-2

This PR removes the `--no-suggest` flag from the `composer install` step.

