### PR TITLE
Remove deprecated '--no-suggest' flag

### DIFF
--- a/ci/laravel.yml
+++ b/ci/laravel.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Generate key
       run: php artisan key:generate
     - name: Directory Permissions


### PR DESCRIPTION
From the upgrade guide for Composer v2.0:
> Deprecated --no-suggest flag as it is not needed anymore

https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-composer-cli-users