### PR TITLE
fix: use the IMAGE_NAME variable

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -72,5 +72,5 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag image $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
The PR tries to fix a behavior of the existing Github Action - "Publish Docker Image"

Current Behavior:
* changing the `IMAGE_NAME` variable breaks the build

Expected Behavior:
* changing the `IMAGE_NAME` variable should not break the build
