### PR TITLE
Bump setup-python from v1 to v2

### DIFF
--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
The `v2` version of [setup-python](https://github.com/marketplace/actions/setup-python) was recently released.

All the Python starter workflows that currently use `actions/setup-python@v1` should be updated to use  `actions/setup-python@v2`
