### PR TITLE
Use cargo check instead of build

### DIFF
--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo check --verbose
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
[`cargo check`](https://doc.rust-lang.org/cargo/commands/cargo-check.html) is usually faster than `cargo build`, but for the purposes of testing if code compiles, has the same effect.

The results of `cargo check` are cached for use by other Cargo subcommands (e.g. `cargo build`), so the run will _fail_ faster, but succeed in more-or-less the same amount of time.