### PR TITLE
Define OTP/Elixir versions as strings

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Setup elixir
       uses: actions/setup-elixir@v1
       with:
-        elixir-version: 1.9.4 # Define the elixir version [required]
-        otp-version: 22.2 # Define the OTP version [required]
+        elixir-version: '1.9.4' # Define the elixir version [required]
+        otp-version: '22.2' # Define the OTP version [required]
     - name: Install Dependencies
       run: mix deps.get
     - name: Run Tests


### PR DESCRIPTION
As now [recommended](https://github.com/actions/setup-elixir/tree/2071beb570a53fb599fbd638d0a4f4577d57143d#usage) in the action's README, the configuration versions should be strings so that YAML parsing doesn't truncate something like `23.0` to `23`, which isn't equivalent.