### PR TITLE
Update workflow job name

### DIFF
--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  sync:
+  validate-data:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Just saw that the job was named the same as the sync one that I "adapted" it from, which meant I wasn't able to select it for a branch protection. This should fix that