### PR TITLE
Add Symfony template

### DIFF
--- a/ci/properties/symfony.properties.json
+++ b/ci/properties/symfony.properties.json
@@ -1,0 +1,9 @@
+{
+    "name": "Symfony",
+    "description": "Test a Symfony project.",
+    "iconName": "php",
+    "categories": [
+        "PHP",
+        "Symfony"
+    ]
+}

--- a/ci/symfony.yml
+++ b/ci/symfony.yml
@@ -1,0 +1,32 @@
+name: Symfony
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  symfony-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+
+    - name: Directory Permissions
+      run: chmod -R 777 var
+
+    - name: Create Database
+      run: |
+        mkdir -p data
+        touch data/database_test.sqlite
+
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      env:
+        DATABASE_URL: sqlite:///%kernel.project_dir%/data/database_test.sqlite
+
+      run: ./bin/phpunit


### PR DESCRIPTION
Template to setup minimal environment to run unit and functional tests in Symfony using PHPUnit ([Symfony's PHPUnit Bridge](https://symfony.com/doc/current/components/phpunit_bridge.html))

Briefly the template does:
- run a environment with ubuntu latest version
- checkout your code in the environment
- add directory permissions
- create a empty sqlite database
- execute the tests via phpunit injecting a couple of environment variables in order to use the sqlite database created