### PR TITLE
Improve maven.yml

### DIFF
--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Changes:
- Write out `-B` as `--batch-mode` to make it easier to understand or searchable by users not familiar with all Maven command line options
- Remove `--file pom.xml` because it is the default anyways. Or does it exist to indicate how users could specify a different file?
- Add `--update-snapshots` to force update snapshots (otherwise it might use stale versions), see [this StackOverflow question asking about the behavior](https://stackoverflow.com/questions/29020716). Note that this overwrites locally installed packages, but should probably not be an issue for the great majority of projects.
- Run all phases up to including `verify` (instead of `package` only) to also run integration tests

Note that [GitHub Help: Building and testing Java with Maven](https://help.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-maven) would have to be updated accordingly.

For further reading:
- [Maven CLI Options Reference](https://maven.apache.org/ref/current/maven-embedder/cli.html)
- [Introduction to the Build Lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html)