### PR TITLE
Make NPM_TOKEN consistent with GITHUB_TOKEN

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-gpr:
     needs: build


### PR DESCRIPTION
It was `npm_token` before, but for GitHub it's `GITHUB_TOKEN`. This makes them be the same, all-cap case.