### PR TITLE
Fixed issue where we were using a variable to reference the signing cert name

### DIFF
--- a/ci/dotnet-core-desktop.yml
+++ b/ci/dotnet-core-desktop.yml
@@ -105,7 +105,7 @@ jobs:
 
     # Remove the pfx
     - name: Remove the pfx
-      run: Remove-Item -path $env:Wap_Project_Directory\$env:Signing_Certificate
+      run: Remove-Item -path $env:Wap_Project_Directory\GitHubActionsWorkflow.pfx
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
     - name: Upload build artifacts


### PR DESCRIPTION
When I created the starter workflow, I drew heavily from a Ci.yml file that used an environment variable to store the .pfx.  However, to simplify the number of variables we used in this starter-workflow, I deleted the variable throughout the code except on one line.

Hat tip to Matteo Pagani for finding this!
