### PR TITLE
Updates hashicorp/setup-terraform version to v1.1.0

### DIFF
--- a/ci/terraform.yml
+++ b/ci/terraform.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v1.1.0
       with:
         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 


### PR DESCRIPTION
# Previous behavior
`hashicorp/setup-terraform@v1` performs a checkout of the latest Terraform _beta_ release (0.13) when no version is specified

# New behavior
`hashicorp/setup-terraform@v1.1.0` performs a checkout of the latest Terraform _stable_ release (0.12) when no version is specified
