### PR TITLE
Update PHP workflow to use shivammathur/setup-php

### DIFF
--- a/ci/php.yml
+++ b/ci/php.yml
@@ -29,10 +29,10 @@ jobs:
       uses: shivammathur/setup-php@dd27d4eb8158e1dd5bd52a143a7468d7a7fb302a
       with:
         php-version: ${{ matrix.php-version }}
-        # extension-csv: mbstring, intl # (optional) specify the extensions you want to enable/install.
-        # ini-values-csv: short_open_tag=On # (optional) specify custom php.ini values.
-        # coverage: xdebug # (optional) specify coverage driver.
-        # pecl: false # (optional) use PECL as fallback to install extensions.
+        # extensions: mbstring, intl # (optional) Specify the extensions you want to add or remove.
+        # ini-values: short_open_tag=On # (optional) Specify the values you want to add to php.ini.
+        # coverage: xdebug # (optional) Specify the code coverage driver you want to setup.
+        # tools: pecl # (optional) Specify the tools you want to setup
       
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -26,7 +26,7 @@ jobs:
     # Setup PHP environment.
     # Docs: https://github.com/shivammathur/setup-php/blob/master/README.md    
     - name: Set up PHP ${{ matrix.php-version }}
-      uses: shivammathur/setup-php@dd27d4eb8158e1dd5bd52a143a7468d7a7fb302a
+      uses: shivammathur/setup-php@7961bc11b161170a2cf13fbe3573edb88fad7c29
       with:
         php-version: ${{ matrix.php-version }}
         # extensions: mbstring, intl # (optional) Specify the extensions you want to add or remove.

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -1,4 +1,9 @@
-name: PHP Composer
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: PHP
 
 on:
   push:
@@ -10,18 +15,37 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        php-version: ['7.2', '7.3', '7.4']
 
     steps:
     - uses: actions/checkout@v2
 
+    # Setup PHP environment.
+    # Docs: https://github.com/shivammathur/setup-php/blob/master/README.md    
+    - name: Set up PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@dd27d4eb8158e1dd5bd52a143a7468d7a7fb302a
+      with:
+        php-version: ${{ matrix.php-version }}
+        # extension-csv: mbstring, intl # (optional) specify the extensions you want to enable/install.
+        # ini-values-csv: short_open_tag=On # (optional) specify custom php.ini values.
+        # coverage: xdebug # (optional) specify coverage driver.
+        # pecl: false # (optional) use PECL as fallback to install extensions.
+      
     - name: Validate composer.json and composer.lock
       run: composer validate
-      
+
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v2
       with:
-        path: vendor
+        path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-php-


### PR DESCRIPTION
Please **add to this description** at the bottom :point_down:

- [x] A good description of the workflow at the bottom of this page.
- [x] Some links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [x] The workflow filename of CI workflows should be the name of the language or platform, in lower case.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").

  The workflow filename of publishing workflows should be the name of the language or platform, in lower case, followed by "-publish".
- [x] Includes a matching `ci/properties/*.properties.json` file.
- [x] Use sentence case for the names of workflows and steps, for example "Run tests".
- [x] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] CI workflows should run on `push` to `branches: [ master ]` and `pull_request` to `branches: [ master ]`.

Some general notes:

- [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  Workflows using these actions must reference the action using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] This workflow must not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] This workflow must not use a paid service or product.

-----

Continution of work done in #222 to follow new guidelines from #451

This updates the php workflow to use [shivammathur/setup-php](https://github.com/shivammathur/setup-php) action to configure PHP for a variety of versions. This is some amount of the de-facto action to do this and is used by a variety of the big PHP projects (e.g. symfony) and I would say is a good candidate for usage in the official starter file This also promotes the starter file to a similar level as the other languages (e.g. python, nodejs).