### PR TITLE
Improve name of "Setup elixir" step in Elixir workflow

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup elixir
+    - name: Set up Elixir
       uses: actions/setup-elixir@v1
       with:
         elixir-version: '1.9.4' # Define the elixir version [required]


### PR DESCRIPTION
This just changes the name of the "Setup elixir" step to "Set up Elixir". cc https://github.com/actions/setup-elixir/issues/33