### PR TITLE
elixir.yml: Specify latest Elixir/OTP versions

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Set up Elixir
       uses: actions/setup-elixir@v1
       with:
-        elixir-version: '1.9.4' # Define the elixir version [required]
-        otp-version: '22.2' # Define the OTP version [required]
+        elixir-version: '1.10.3' # Define the elixir version [required]
+        otp-version: '22.3' # Define the OTP version [required]
     - name: Install Dependencies
       run: mix deps.get
     - name: Run Tests


### PR DESCRIPTION
Source for this being latest Elixir: https://github.com/elixir-lang/elixir/releases

There is an OTP 23.0 (https://www.erlang.org/downloads) but https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp indicates Elixir 1.10 isn't known to be compatible with a later OTP than 22.
