### PR TITLE
Update deprecated for actions/setup-ruby  to  on gem-push.yml

### DIFF
--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6.x
 
     - name: Publish to GPR
       run: |


### PR DESCRIPTION
refs #573
Update deprecated for actions/setup-ruby `version` to `ruby-version` on gem-push.yml.
