### PR TITLE
Add manually triggered workflow template

### DIFF
--- a/ci/manual.yml
+++ b/ci/manual.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow that is manually triggered
+
+name: Manual workflow
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      name:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'Person to greet'
+        # Default value if no value is explicitly provided
+        default: 'World'
+        # Input has to be provided for the workflow to run
+        required: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  greet:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Runs a single command using the runners shell
+    - name: Send greeting
+      run: echo "Hello ${{ github.event.inputs.name }}"

--- a/ci/properties/manual.properties.json
+++ b/ci/properties/manual.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Manual workflow",
+    "description": "Simple workflow that is manually triggered.",
+    "iconName": "blank",
+    "categories": null
+}


### PR DESCRIPTION
This repository contains configuration for what users see when they click on the `Actions` tab.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository

---

Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request.

Please **add to this description** at the bottom :point_down:

- [x] A good description of the workflow at the bottom of this page.
- [x] Some links to the language or tool will be nice (unless its really obvious)

In the workflow and properties files:

- [x] The workflow filename of CI workflows should be the name of the language or platform, in lower case.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").

  The workflow filename of publishing workflows should be the name of the language or platform, in lower case, followed by "-publish".
- [x] Includes a matching `ci/properties/*.properties.json` file.
- [x] Use sentence case for the names of workflows and steps, for example "Run tests".
- [x] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] CI workflows should run on `push` to `branches: [ master ]` and `pull_request` to `branches: [ master ]`.
- [x] Packaging workflows should run on `release` with `types: [ created ]`.

Some general notes:

- [x] This workflow must only use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  Workflows using these actions must reference the action using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] This workflow must not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] This workflow must not use a paid service or product.

This adds a new workflow template demonstrating the use of the new `workflow_dispatch` event to have a workflow that can be manually triggered. 

It also demonstrates the use of `inputs` and usage of the provided values in the workflow, see https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow for more details.