### PR TITLE
Include Bearer in GEM_HOST_API_KEY

### DIFF
--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6.x
 
     - name: Publish to GPR
       run: |

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -27,7 +27,7 @@ jobs:
         gem build *.gemspec
         gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
       env:
-        GEM_HOST_API_KEY: ${{secrets.GPR_AUTH_TOKEN}}
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: username
 
     - name: Publish to RubyGems
@@ -39,4 +39,4 @@ jobs:
         gem build *.gemspec
         gem push *.gem
       env:
-        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+        GEM_HOST_API_KEY: "Bearer ${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -28,7 +28,7 @@ jobs:
         gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
-        OWNER: username
+        OWNER: ${{ github.repository_owner }}
 
     - name: Publish to RubyGems
       run: |

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -23,7 +23,7 @@ jobs:
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         gem build *.gemspec
         gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
       env:


### PR DESCRIPTION
Fixes github/c2c-package-registry#2154

Ruby 2.7 now includes built in support for the `GEM_HOST_API_KEY` env var. When set, this is used in preference to the `--KEY` / `.gem/credentials` option. The `GEM_HOST_API_KEY` option _must_ include a `Bearer` prefix.

When not set, GitHub Packages will fail with:

```
Your request could not be authenticated by the GitHub Packages service. Please ensure your access token is valid and has the appropriate scopes configured.
```

https://github.com/saigkill/publican_creators/runs/853772278?check_suite_focus=true#step:5:17

### What this PR does

- Include `Bearer` in `GEM_HOST_API_KEY` env var (for compatibility with 2.7+)
- Use `${{secrets.GITHUB_TOKEN}}` instead of `${{secrets.GPR_AUTH_TOKEN}}`
- Use `${{ github.repository_owner }}` as the default `OWNER`
- Use `ruby-version` instead of `version`
  - This gets rid of the warning: `Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use ruby-version instead`

### Questions

If we changed to using Ruby 2.7, the following could be removed:

```
        mkdir -p $HOME/.gem
        touch $HOME/.gem/credentials
        chmod 0600 $HOME/.gem/credentials
        printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
```

The publish step would be simply:

```
    - name: Publish to GPR
      run: gem push --host https://rubygems.pkg.github.com/${OWNER} *.gem
      env:
        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
        OWNER: ${{ github.repository_owner }}
```

Should we default to using Ruby 2.7 and/or mention this as a comment?

2. We're doing `gem build *.gemspec` as part of `Publish to GPR` and `Publish to RubyGems`. Should this be a separate step?