### PR TITLE
Rename to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ It is not:
 
 ---
 
-Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/master/CONTRIBUTING.md). Here's a few things for you to consider in this pull request.
+Thank you for sending in this pull request. Please make sure you take a look at the [contributing file](https://github.com/actions/starter-workflows/blob/main/CONTRIBUTING.md). Here's a few things for you to consider in this pull request.
 
 Please **add to this description** at the bottom :point_down:
 

--- a/.github/workflows/sync_ghes.yaml
+++ b/.github/workflows/sync_ghes.yaml
@@ -3,7 +3,7 @@ name: Sync workflows for GHES
 on:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   sync:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 Hi there 👋 We are excited that you want to contribute a new workflow to this repo. By doing this you are helping people get up and running with GitHub Actions and that's cool 😎.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](https://github.com/actions/starter-workflows/blob/master/LICENSE).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](https://github.com/actions/starter-workflows/blob/main/LICENSE).
 
 Please note that this project is released with a [Contributor Code of Conduct](
-https://github.com/actions/.github/blob/master/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+https://github.com/actions/.github/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 Before merging a new workflow, the following requirements need to be met:
 

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -148,18 +148,18 @@ async function checkWorkflow(
     console.log("Switch to GHES branch");
     await exec("git", ["checkout", "ghes"]);
 
-    // In order to sync from master, we might need to remove some workflows, add some
+    // In order to sync from main, we might need to remove some workflows, add some
     // and modify others. The lazy approach is to delete all workflows first, and then
-    // just bring the compatible ones over from the master branch. We let git figure out
+    // just bring the compatible ones over from the main branch. We let git figure out
     // whether it's a deletion, add, or modify and commit the new state.
     console.log("Remove all workflows");
     await exec("rm", ["-fr", ...settings.folders]);
     await exec("rm", ["-fr", "../../icons"]);
 
-    console.log("Sync changes from master for compatible workflows");
+    console.log("Sync changes from main for compatible workflows");
     await exec("git", [
       "checkout",
-      "master",
+      "main",
       "--",
       ...Array.prototype.concat.apply(
         [],


### PR DESCRIPTION
This is part of #589 and covers any cases of `master` in this repository, replacing with `main`.

The last couple of references to `master` in this repo are to other repositories.