### PR TITLE
Update .NET Core SDK version

### DIFF
--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 3.1.301
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Blazor projects fail to build in 3.1.101 due to a bug in the .NET Core SDK. Updating the SDK to the latest version (3.1.301) fixes this bug.