### PR TITLE
Update artifact actions from v1 to v2

### DIFF
--- a/ci/dotnet-core-desktop.yml
+++ b/ci/dotnet-core-desktop.yml
@@ -109,7 +109,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: MSIX Package
         path: ${{ env.Wap_Project_Directory }}\AppPackages


### PR DESCRIPTION
Both the [upload-artifact](https://github.com/actions/upload-artifact) and [download-artifact](https://github.com/actions/download-artifact) are on `v2`. Our public documentation also points to `v2` and was recently updated: https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts

Doing a quick search, I only found one place in our starter workflows that uses the artifact actions. This small PR just bumps up the versions from v1 to v2