### PR TITLE
dotnet-Workflows: Use latest channel version

### DIFF
--- a/ci/dotnet-core-desktop.yml
+++ b/ci/dotnet-core-desktop.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 3.1
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/ci/dotnet-core.yml
+++ b/ci/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 3.1
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Fixes #619 

Please make sure, that all workflows work with the latest versions by default.

