### PR TITLE
npm-publish / published release instead of created

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Hi,

A very little change on the trigger event from `created` release to `published` to avoid package published when a release draft is created

Because currently, it will publish each time a draft is created, which is not what we want usually :)

Note that I used `published` instead of `released` to include `pre-release`