### PR TITLE
Update Publish Docker template to publish to GitHub Container Registry

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -50,12 +50,13 @@ jobs:
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Log into GitHub Container Registry
+      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push image
+      - name: Push image to GitHub Container Registry
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')

--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Push image to GitHub Container Registry
         run: |
-          IMAGE_ID=ghcr.io/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION
GitHub Container Registry (GHCR) is intended to supersede the Docker service in GitHub Packages. I've updated the Publish Docker template to use GHCR which was released as a public beta on 9/1/20:

- GHCR doesn't support `GITHUB_TOKEN` so a PAT will need to be created and saved as `CR_PAT` instead.
- The URL is ghcr.io instead of docker.pkg.github.com.
- The repo path part is no longer required. You publish to ghcr.io/[org]/[image-name].