### PR TITLE
Update to use the $registry-url() token

### DIFF
--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://npm.pkg.github.com/
+          registry-url: $registry-url(npm)
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
Replace the registry url with a token that will auto-replace, but be the correct URL in an enterprise environment.