### PR TITLE
Fix on step name for pylint action

### DIFF
--- a/ci/pylint.yml
+++ b/ci/pylint.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-    - name: Test with pytest
+    - name: Analysing the code with pylint
       run: |
         pylint `ls -R|grep .py$|xargs`


### PR DESCRIPTION
On analyzing the code with `pylint`, the name of the step is `Test with pytest`, which is certainly not what it does.

This repository contains configuration for what users see when they click on the `Actions` tab.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository

---

**Please note that we are not accepting new starter workflows at this time. Updates to existing starter workflows are fine.**

---

In the workflow and properties files:

- [x] The workflow filename of CI workflows should be the name of the language or platform, in lower case.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").

  The workflow filename of publishing workflows should be the name of the language or platform, in lower case, followed by "-publish".
- [x] Includes a matching `ci/properties/*.properties.json` file.
- [x] Use sentence case for the names of workflows and steps, for example "Run tests".
- [x] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] CI workflows should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [x] Packaging workflows should run on `release` with `types: [ created ]`.

Some general notes:

- [x] This workflow must only use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  Workflows using these actions must reference the action using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] This workflow must not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] This workflow must not use a paid service or product.
