### PR TITLE
Change parameter to pylint

### DIFF
--- a/ci/pylint.yml
+++ b/ci/pylint.yml
@@ -19,4 +19,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint `ls -R|grep .py$|xargs`
+        pylint **/*.py


### PR DESCRIPTION
Previous operation does not actually do work recursively and this works for windows too.
can also use pylint $(git ls-files '*.py')