### PR TITLE
ci/d: Use version instead of hash

### DIFF
--- a/ci/d.yml
+++ b/ci/d.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
+    - uses: dlang-community/setup-dlang@v1
 
     - name: 'Build & Test'
       run: |


### PR DESCRIPTION
```
There are plenty of other actions in this repository using a version
that is not certified by Github. The disclaimer makes this obvious.
The action in question is not simply a user's action, but maintained
by dlang-community, which is overseen by the D Language Foundation.
The recent set of changes to actions means that this workflow is currently
broken, as it was previously using add-path and set-env.
Keeping on upgrading the hash will provide a terrible user experience,
as it is likely to be forgotten, and will also require user-intervention
when another set of change breaks this action, hence why this updates
the hash to a version instead of changing it to the latest hash.
```

I note that the contributing guidelines have evolved to make the hash a recommendation rather than a requirement, thanks for that:
> - [ ] This workflow must only use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
> - [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag. 