### PR TITLE
Use consistent calls to pip

### DIFF
--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
`pip` was called in two different ways which is a bit inconsistent, this change just makes it so that it is called in the same way both times.