### PR TITLE
dotnet-Workflows: Use latest channel version

### DIFF
--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 5.0.x
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/ci/dotnet.yml
+++ b/ci/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Fixes #619 

Originally fixed by #620 
This version was updated to .NET 5
