### PR TITLE
Update OpenShift starter with new actions

### DIFF
--- a/ci/openshift.yml
+++ b/ci/openshift.yml
@@ -1,48 +1,147 @@
-# This workflow will set up the oc CLI in your GitHub Action workflow and deploy your application to your OpenShift cluster.
-#
-# This workflow assumes you already have access to an OpenShift cluster.
-# For instructions to get started with OpenShift see https://www.openshift.com/try
-#
-# To configure this workflow:
-#
-# 1. Set up a secret in your repository named OPENSHIFT_SERVER_URL with the value of your OpenShift server URL.
-# 
-# 2. Set up another secret named API_TOKEN with the value of a valid token to authenticate to OpenShift.
-#
-# 3. Change the values for the PROJECT and APP_NAME environment variables  (below).
-#
-# For more information on the OpenShift Action, refer to https://github.com/redhat-developer/openshift-actions
-name: Build and Deploy to OpenShift
-on:
-  push:
-    branches:
-      - $default-branch
+### The OpenShift Starter workflow will:
+# - Checkout your repository
+# - Perform a Docker build
+# - Push the built image to an image registry
+# - Log in to your OpenShift cluster
+# - Create an OpenShift app from the image and expose it to the internet.
 
-# Environment variables available to all jobs and steps in this workflow
+### Before you begin:
+# - Have write access to a container image registry such as quay.io or Dockerhub.
+# - Have access to an OpenShift cluster.
+#   - For instructions to get started with OpenShift see https://www.openshift.com/try
+# - The project you wish to add this workflow to should have a Dockerfile.
+#   - If you don't have a Dockerfile at the repository root, see the buildah-build step.
+#   - Builds from scratch are also available, but require more configuration.
+
+### To get the workflow running:
+# 1. Add this workflow to your repository.
+# 2. Edit the top-level 'env' section, which contains a list of environment variables that must be configured.
+# 3. Create the secrets referenced in the 'env' section under your repository Settings.
+# 4. Edit the 'branches' in the 'on' section to trigger the workflow on a push to your branch.
+# 5. Commit and push your changes.
+
+# For a more sophisticated example, see https://github.com/redhat-actions/spring-petclinic/blob/main/.github/workflows/petclinic-sample.yaml
+# Also see our GitHub organization, https://github.com/redhat-actions/
+
+name: OpenShift
+
+# ⬇️  Modify the fields marked with ⬇️ to fit your project, and create any secrets that are referenced.
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
 env:
-  PROJECT: myproject
-  APP_NAME: myapp
+  # ⬇️ EDIT with your registry and registry path.
+  REGISTRY: quay.io/<username>
+  # ⬇️ EDIT with your registry username.
+  REGISTRY_USER: <username>
+  REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+
+  # ⬇️ EDIT to log into your OpenShift cluster and set up the context.
+  # See https://github.com/redhat-actions/oc-login#readme for how to retrieve these values.
+  OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
+  OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+
+  # ⬇️ EDIT with the port your application should be accessible on.
+  APP_PORT: 8080
+
+  # ⬇️ EDIT if you wish to set the kube context's namespace after login. Leave blank to use the default namespace.
+  OPENSHIFT_NAMESPACE: ""
+
+  # If you wish to manually provide the APP_NAME and TAG, set them here, otherwise they will be auto-detected.
+  APP_NAME: ""
+  TAG: ""
+
+on:
+  # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+  push:
+    # Edit to the branch(es) you want to build and deploy on each push.
+    branches: [ $default-branch ]
 
 jobs:
-  build:
-    name: Setup and Deploy
-    runs-on: ubuntu-latest
+  openshift-ci-cd:
+    name: Build and deploy to OpenShift
+    runs-on: ubuntu-20.04
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    # Set up the oc CLI, authenticate and deploy to OpenShift
-    - name: Set up oc CLI and deploy to OpenShift
-      uses: redhat-developer/openshift-actions@v2.1.0
-      with:
-        version: '4.3'
-        openshift_server_url: ${{ secrets.OPENSHIFT_SERVER_URL }}
-        parameters: '{"apitoken": "${{ secrets.API_TOKEN }}", "acceptUntrustedCerts": "true"}'
-        cmd: |
-          oc project ${PROJECT}
-          oc new-app ${GITHUB_WORKSPACE} --name ${APP_NAME}
-    # Expose the service created by using the oc CLI installed previously
-    - name: Execute additional oc commands
+    - name: Determine app name
+      if: env.APP_NAME == ''
       run: |
-        oc expose svc/${{ env.APP_NAME }}
+        echo "APP_NAME=$(basename $PWD)" | tee -a $GITHUB_ENV
+
+    - name: Determine tag
+      if: env.TAG == ''
+      run: |
+        echo "TAG=${GITHUB_SHA::7}" | tee -a $GITHUB_ENV
+
+    # https://github.com/redhat-actions/buildah-build#readme
+    - name: Build from Dockerfile
+      uses: redhat-actions/buildah-build@v1
+      with:
+        image: ${{ env.APP_NAME }}
+        tag: ${{ env.TAG }}
+        # If you don't have a dockerfile, see:
+        # https://github.com/redhat-actions/buildah-build#building-from-scratch
+        # Otherwise, point this to your Dockerfile relative to the repository root.
+        dockerfiles: |
+          ./Dockerfile
+
+    # https://github.com/redhat-actions/push-to-registry#readme
+    - name: Push to registry
+      id: push-to-registry
+      uses: redhat-actions/push-to-registry@v1
+      with:
+        image: ${{ env.APP_NAME }}
+        tag: ${{ env.TAG }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+
+    # The path the image was pushed to is now stored in ${{ steps.push-to-registry.outputs.registry-path }}
+
+    # oc-login works on all platforms, but oc must be installed first.
+    # The GitHub Ubuntu runner already includes oc.
+    # Otherwise, https://github.com/redhat-actions/oc-installer#readme is available.
+
+    # https://github.com/redhat-actions/oc-login#readme
+    - name: Log in to OpenShift
+      uses: redhat-actions/oc-login@v1
+      with:
+        openshift_server_url: ${{ env.OPENSHIFT_SERVER }}
+        openshift_token: ${{ env.OPENSHIFT_TOKEN }}
+        insecure_skip_tls_verify: true
+        namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+
+    # This step should create a deployment, service, and route to run your app and expose it to the internet.
+    # Feel free to replace this with 'oc apply', 'helm install', or however you like to deploy your app.
+    - name: Create and expose app
+      run: |
+        export IMAGE="${{ steps.push-to-registry.outputs.registry-path }}"
+        export PORT=${{ env.APP_PORT }}
+
+        export SELECTOR="app=${{ env.APP_NAME }}"
+        echo "SELECTOR=$SELECTOR" >> $GITHUB_ENV
+
+        set -x
+        # Take down any old deployment
+        oc delete all --selector="$SELECTOR"
+        oc new-app --name $APP_NAME --docker-image="$IMAGE"
+
+        # Make sure the app port is exposed
+        oc patch svc $APP_NAME -p "{ \"spec\": { \"ports\": [{ \"name\": \"$PORT-tcp\", \"port\": $PORT }] } }"
+        oc expose service $APP_NAME --port=$PORT
+
+        oc get all --selector="$SELECTOR"
+        set +x
+
+        export ROUTE="$(oc get route $APP_NAME -o jsonpath='{.spec.host}')"
+        echo "$APP_NAME is exposed at $ROUTE"
+        echo "ROUTE=$ROUTE" >> $GITHUB_ENV
+
+    - name: View application route
+      run: |
+        [[ -n ${{ env.ROUTE }} ]] || (echo "Determining application route failed in previous step"; exit 1)
+        echo "======================== Your application is available at: ========================"
+        echo ${{ env.ROUTE }}
+        echo "==================================================================================="
+        echo
+        echo "Your app can be taken down with: \"oc delete all --selector='${{ env.SELECTOR }}'\""

--- a/ci/openshift.yml
+++ b/ci/openshift.yml
@@ -1,3 +1,8 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 ### The OpenShift Starter workflow will:
 # - Checkout your repository
 # - Perform a Docker build

--- a/ci/properties/openshift.properties.json
+++ b/ci/properties/openshift.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "OpenShift",
-    "description": "Set up the oc CLI in your GitHub Actions workflow and deploy your application to OpenShift.",
+    "description": "Build a Docker-based project and deploy it to OpenShift.",
     "creator": "Red Hat",
     "iconName": "openshift",
     "categories": null


### PR DESCRIPTION
This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository

---

**Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

In the workflow and properties files:

- [x] The workflow filename of CI workflows should be the name of the language or platform, in lower case.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").

  The workflow filename of publishing workflows should be the name of the language or platform, in lower case, followed by "-publish".
- [x] Includes a matching `ci/properties/*.properties.json` file.
- [x] Use sentence case for the names of workflows and steps, for example "Run tests".
- [x] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
- [x] Include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] CI workflows should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Code Scanning workflows should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly`.

Some general notes:

- [ ] This workflow must only use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.
