### PR TITLE
Update ruby.yml

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -24,7 +24,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
       with:
         ruby-version: 2.6
     - name: Install dependencies


### PR DESCRIPTION
Noticed that this version of setup-ruby causes problems with the `set-env` deprecation. This just bumps it up to the latest commit on https://github.com/ruby/setup-ruby/
