### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
-* @actions-experience @advanced-security-code-scanning
+* @actions/actions-experience
+
+/code-scanning/ @actions/advanced-security-code-scanning


### PR DESCRIPTION
This updates CODEOWNERs to

1. Use the correct team names (`@actions/` was required since these are teams within the Actions org)
2. Use the `/code-scanning/` directory for `@actions/advanced-security-code-scanning`
