### PR TITLE
Add every version of Node.js that is supported upstream

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -16,7 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Documentation of upstream version support: https://nodejs.org/en/about/releases/

This PR adds support for Node.js 15.x because it is supported upstream.

Documentation is also added in code to support this change and ease further changes in the future as needed.

---

Follow-on work

- For people using our CI workflows, we always want to recommend they test including the latest upstream-supported language versions. This type of PR I'm making here can be automated. The easiest way is to compare the upstream languages' list of supported versions against the hardcoded language versions in this repository using CI and produce errors when not included.