### PR TITLE
Update ruby.yml to use the latest release of ruby/setup-ruby

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -24,7 +24,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: 2.6
     - name: Install dependencies


### PR DESCRIPTION
https://github.com/ruby/setup-ruby/releases/tag/v1.61.0

Is it allowed to just use `uses: ruby/setup-ruby@v1` instead of a full sha nowadays in starter-workflows? (it seems so from the text below)
That seems much better.

---
- [x] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```