### PR TITLE
update setup-dlang to v1.0.3

### DIFF
--- a/ci/d.yml
+++ b/ci/d.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: dlang-community/setup-dlang@7c3e57bdc1ff2d8994f00e61b3ef400e67d2d7ac
+    - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
 
     - name: 'Build & Test'
       run: |


### PR DESCRIPTION
This fixes the previous version using the outdated `::set-env` command which is disabled now. (See https://github.com/dlang-community/setup-dlang/issues/34)

Commit is of https://github.com/dlang-community/setup-dlang/releases/tag/v1.0.3