### PR TITLE
haskell: ghc 8.10 and cabal 3.2

### DIFF
--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1
       with:
-        ghc-version: '8.8.2'
-        cabal-version: '3.0'
+        ghc-version: '8.10.3'
+        cabal-version: '3.2'
 
     - name: Cache
       uses: actions/cache@v1


### PR DESCRIPTION
keep using the latest haskell offerings when bootstrapping the action scripts.