### PR TITLE
python: include python 3.9 for the build

### DIFF
--- a/ci/django.yml
+++ b/ci/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
adding latest python 3.9 into the bootstrap script. 

---

relates to https://www.python.org/downloads/release/python-390/ (`Release Date: Oct. 5, 2020`)