### PR TITLE
ruby: add ruby 2.7 and 3.0 into bootstrap script

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -17,6 +17,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +29,7 @@ jobs:
     # uses: ruby/setup-ruby@v1
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
-        ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
ruby: add ruby 2.7 and 3.0 into bootstrap script

---

relates to https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/