### PR TITLE
Recommend the bundler-cache option

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -27,7 +27,6 @@ jobs:
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
* It is both more convenient and significantly faster.
* It's also recommended in the action's README: https://github.com/ruby/setup-ruby/#usage