### PR TITLE
Clarify pre-requisites, tasks for onboarding of new starter workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ It is not:
 **Some general notes:**
 
 - [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
-- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
+- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
     ```
     # This workflow uses actions that are not certified by GitHub.
     # They are provided by a third-party and are governed by

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,12 +24,12 @@ It is not:
 
 - [ ] Should be contained in a file having the name of the language or platform, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
 - [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
-- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build")
+- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
 - [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
 
 **For _CI_ workflows, the workflow:**
 
-- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci)
+- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
 - [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
 - [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
 - [ ] Packaging workflows should run on `release` with `types: [ created ]`.
@@ -37,7 +37,7 @@ It is not:
 
 **For _Code Scanning_ workflows, the workflow:**
 
-- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci)
+- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
 - [ ] Should include a matching `code-scanning/properties/*.properties.json` file.
 - [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@ It is not:
 **For _Code Scanning_ workflows, the workflow:**
 
 - [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
-- [ ] Should include a matching `code-scanning/properties/*.properties.json` file, with properties set as follows:
+- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
   - [ ] `name`: Name of the Code Scanning integration.
   - [ ] `organization`: Name of the organization producing the Code Scanning integration.
   - [ ] `description`: Short description of the Code Scanning integration.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,9 @@ It is not:
 * A place for you to create a workflow for your repository
 -->
 
+## Pre-requisites
+
+- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,12 @@ It is not:
 **For _Code Scanning_ workflows, the workflow:**
 
 - [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
-- [ ] Should include a matching `code-scanning/properties/*.properties.json` file.
+- [ ] Should include a matching `code-scanning/properties/*.properties.json` file, with properties set as follows:
+  - [ ] `name`: Name of the Code Scanning integration.
+  - [ ] `organization`: Name of the organization producing the Code Scanning integration.
+  - [ ] `description`: Short description of the Code Scanning integration.
+  - [ ] `languages`: Array of languages supported by the Code Scanning integration.
+  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
 - [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).
 
 **Some general notes:**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,13 @@
+<!--
+IMPORTANT:
+
 This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.
 
 It is not:
 * A playground to try out scripts
 * A place for you to create a workflow for your repository
+-->
+
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ It is not:
 
 ---
 
-**Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**
+### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,23 +18,33 @@ It is not:
 
 ---
 
-In the workflow and properties files:
+## Tasks
 
-- [ ] The workflow filename of CI workflows should be the name of the language or platform, in lower case.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
+**For _all_ workflows, the workflow:**
 
-  The workflow filename of publishing workflows should be the name of the language or platform, in lower case, followed by "-publish".
-- [ ] Includes a matching `ci/properties/*.properties.json` file.
-- [ ] Use sentence case for the names of workflows and steps, for example "Run tests".
-- [ ] The name of CI workflows should only be the name of the language or platform: for example "Go" (not "Go CI" or "Go Build")
-- [ ] Include comments in the workflow for any parts that are not obvious or could use clarification.
-- [ ] CI workflows should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
+- [ ] Should be contained in a file having the name of the language or platform, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
+- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
+- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build")
+- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
+
+**For _CI_ workflows, the workflow:**
+
+- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci)
+- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
+- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
 - [ ] Packaging workflows should run on `release` with `types: [ created ]`.
-- [ ] Code Scanning workflows should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly`.
+- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).
 
-Some general notes:
+**For _Code Scanning_ workflows, the workflow:**
 
-- [ ] This workflow must only use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
-- [ ] This workflow must only use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
+- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci)
+- [ ] Should include a matching `code-scanning/properties/*.properties.json` file.
+- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).
+
+**Some general notes:**
+
+- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
+- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We recommend that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
     ```
     # This workflow uses actions that are not certified by GitHub.
     # They are provided by a third-party and are governed by

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,7 @@ It is not:
   - [ ] `name`: Name of the Code Scanning integration.
   - [ ] `organization`: Name of the organization producing the Code Scanning integration.
   - [ ] `description`: Short description of the Code Scanning integration.
-  - [ ] `languages`: Array of languages supported by the Code Scanning integration.
+  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
   - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
 - [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ It is not:
 
 **For _all_ workflows, the workflow:**
 
-- [ ] Should be contained in a file having the name of the language or platform, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format.  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
+- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
 - [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
 - [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
 - [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.


### PR DESCRIPTION
Proposes tune-ups to the existing PR template. The intent is to clarify requirements for proposing new starter workflows, with a shared section for common requirements, and dedicated sections for each "flavor" of workflow (CI, code scanning, ...).

For new Code Scanning starter workflows, we are requesting membership in our recently relaunched Partner Program.