### PR TITLE
Update dart.yml

### DIFF
--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -1,3 +1,8 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 name: Dart
 
 on:

--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -10,18 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    # Note that this workflow uses the latest stable version of the Dart SDK.
-    # Docker images for other release channels - like dev and beta - are also
-    # available. See https://hub.docker.com/r/google/dart/ for the available
-    # images.
-    container:
-      image:  google/dart:latest
-
     steps:
       - uses: actions/checkout@v2
 
-      - name: Print Dart SDK version
-        run: dart --version
+      # Note: This workflow uses the latest stable version of the Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/dart-lang/setup-dart/blob/main/README.md
+      - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
         run: dart pub get

--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -21,7 +21,8 @@ jobs:
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md
-      - uses: dart-lang/setup-dart@v1
+      # - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
Update Dart starter workflow to use `setup-dart` from the Dart team.

Note that I am a member of the Dart team and am more than happy to answer any questions about these changes.

Major advantages over using this new setup action are:

  1. Enables testing on more operating systems (Linux, Windows, and macOS)
  1. Offers more control over the Dart SDK version to test with (beta & dev channels, specific versions)

Thanks!

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [X] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [X] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [X] Automation and CI workflows cannot be dependent on a paid service or product.
