### PR TITLE
actions/setup-elixir now lives under erlef GH Org

### DIFF
--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: '1.10.3' # Define the elixir version [required]
         otp-version: '22.3' # Define the OTP version [required]

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+
       with:
         elixir-version: '1.10.3' # Define the elixir version [required]
         otp-version: '22.3' # Define the OTP version [required]


### PR DESCRIPTION
[actions/setup-elixir](https://github.com/actions/setup-elixir) is no longer maintained and now suggests using [erlef/setup-elixir](github.com/erlef/setup-elixir)

This should be updated to help new Github Actions users to use the supported action.
