### PR TITLE
Use ruby/setup-ruby@v1 in Ruby starter workflow

### DIFF
--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -24,10 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
I am the main author of ruby/setup-ruby.
I think it's time to simply use `@v1` in this starter workflow.

Even the official documentation about this action, by GitHub, uses `ruby/setup-ruby@v1`:
https://docs.github.com/en/actions/guides/building-and-testing-ruby

Probably the rule below merits updating:

- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```

Does that sound acceptable?

If people actually want maximum security and stability (at the expense of everything else), they should probably pin *everything* down to a full sha (also actions developed by GitHub, they depend on third party packages which might change and have new security issues), but that seems very extreme and inconvenient, so I guess extremely few users would do that, and if they do, they would be well aware to do it for all actions, not just "3rd-party" ones.

Previous discussions about this and how weird and problematic it is to recommend a full sha to people trying GitHub Actions: #448, #709 and probably more.

Starter workflows should make it easy to get started.
If they're more cumbersome to use than the snippets in the documentation, there seems to be a problem.