### PR TITLE
Make the validation strict by default

### DIFF
--- a/ci/php.yml
+++ b/ci/php.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Validate composer.json and composer.lock
-      run: composer validate
+      run: composer validate --strict
 
     - name: Cache Composer packages
       id: composer-cache


### PR DESCRIPTION
Composer maintainer here. 

I would recommend running validate in strict mode by default, as it makes it exit with a non-zero code when there is a warning. By default warnings are not treated as fatal and as such the process still returns 0, but in CI that often means stuff gets missed.