### PR TITLE
Always run composer install even if the vendor dir was restored

### DIFF
--- a/ci/php.yml
+++ b/ci/php.yml
@@ -27,7 +27,6 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: composer install --prefer-dist --no-progress --no-suggest
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"


### PR DESCRIPTION
Composer install should always run IMO, it is the safer way to do this. A few reasons:

- As part of install some scripts may run which do things in directories outside of the cached vendor dir
- Some projects use composer plugins which install packages outside the vendor dir, which means those will not be cached even tho the cache was a hit, so running install always makes sure anything missing will get installed correctly.
- It runs very quickly (<1s) if there is nothing to change, so it's a fairly harmless default IMO, which might save some head-scratching.