### PR TITLE
Add environment: production to partner starter workflows

### DIFF
--- a/ci/alibabacloud.yml
+++ b/ci/alibabacloud.yml
@@ -16,9 +16,6 @@
 #
 # 4. Change the values for the REGION_ID, REGISTRY, NAMESPACE, IMAGE, ACK_CLUSTER_ID, and ACK_DEPLOYMENT_NAME. 
 #
-# 5. Create an environment named "production".
-#    For instructions see https://docs.github.com/en/actions/reference/environments#creating-an-environment. 
-#
 
 name: Build and Deploy to ACK
 

--- a/ci/alibabacloud.yml
+++ b/ci/alibabacloud.yml
@@ -16,6 +16,9 @@
 #
 # 4. Change the values for the REGION_ID, REGISTRY, NAMESPACE, IMAGE, ACK_CLUSTER_ID, and ACK_DEPLOYMENT_NAME. 
 #
+# 5. Create an environment named "production".
+#    For instructions see https://docs.github.com/en/actions/reference/environments#creating-an-environment. 
+#
 
 name: Build and Deploy to ACK
 
@@ -42,6 +45,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: production
     
     steps:
     - name: Checkout

--- a/ci/aws.yml
+++ b/ci/aws.yml
@@ -22,6 +22,9 @@
 # 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 #    See the documentation for each action used below for the recommended IAM policies for this IAM user,
 #    and best practices on handling the access key credentials.
+# 
+# 5. Create an environment named "production".
+#    For instructions see https://docs.github.com/en/actions/reference/environments#creating-an-environment.
 
 on:
   release:
@@ -33,6 +36,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
     - name: Checkout

--- a/ci/aws.yml
+++ b/ci/aws.yml
@@ -22,9 +22,6 @@
 # 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 #    See the documentation for each action used below for the recommended IAM policies for this IAM user,
 #    and best practices on handling the access key credentials.
-# 
-# 5. Create an environment named "production".
-#    For instructions see https://docs.github.com/en/actions/reference/environments#creating-an-environment.
 
 on:
   release:

--- a/ci/ibm.yml
+++ b/ci/ibm.yml
@@ -28,6 +28,7 @@ jobs:
   setup-build-publish-deploy:
     name: Setup, Build, Publish, and Deploy
     runs-on: ubuntu-latest
+    environment: production
     steps:
 
     - name: Checkout

--- a/ci/openshift.yml
+++ b/ci/openshift.yml
@@ -64,6 +64,7 @@ jobs:
   openshift-ci-cd:
     name: Build and deploy to OpenShift
     runs-on: ubuntu-20.04
+    environment: production
 
     steps:
     - uses: actions/checkout@v2

--- a/ci/tencent.yml
+++ b/ci/tencent.yml
@@ -30,6 +30,7 @@ jobs:
   setup-build-publish-deploy:
     name: Setup, Build, Publish, and Deploy
     runs-on: ubuntu-latest
+    environment: production
     steps:
 
     - name: Checkout

--- a/ci/terraform.yml
+++ b/ci/terraform.yml
@@ -54,6 +54,7 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
+    environment: production
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:


### PR DESCRIPTION
Updates the following partner starter workflows to take advantage of [`environment`s](https://docs.github.com/en/actions/reference/environments), which allow for features like [protection rules](https://docs.github.com/en/actions/reference/environments#environment-protection-rules) and [environment secrets](https://docs.github.com/en/actions/reference/environments#environment-secrets).

- Alibaba
- AWS
- IBM
- OpenShift
- Tencent
- Terraform

Prior art: [Azure](https://github.com/actions/starter-workflows/pull/784), [Google](https://github.com/actions/starter-workflows/pull/807)