### PR TITLE
Use actions/setup-node v2

### DIFF
--- a/.github/workflows/sync_ghes.yaml
+++ b/.github/workflows/sync_ghes.yaml
@@ -14,7 +14,7 @@ jobs:
         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
         git config user.email "cschleiden@github.com"
         git config user.name "GitHub Actions"
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
         node-version: '12'
     - name: Check starter workflows for GHES compat

--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12"
 

--- a/ci/azure.yml
+++ b/ci/azure.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: npm install, build, and test

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
       - run: npm ci
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: $registry-url(npm)


### PR DESCRIPTION
Since actions/setup-node v2 has been declared stable since [v2.1.4](https://github.com/actions/setup-node/releases/tag/v2.1.4) (released on 2020-12-16), it should be safe to move everyone to v2.