### PR TITLE
Remove the deprecated "--no-suggest" option from the Composer install step

### DIFF
--- a/ci/php.yml
+++ b/ci/php.yml
@@ -27,7 +27,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md


### PR DESCRIPTION
Hello!

`php.yml` CI workflow starts Composer with the deprecated `--no-suggest` option.

It was fixed in #490 and hasn't been reverted as far as I can see, but the current version of the workflow contains this deprecated option for some strange reason.

Let's try to remove it again!