### PR TITLE
Add recursive write permissions to site directory in jekyll starter workflow

### DIFF
--- a/ci/jekyll.yml
+++ b/ci/jekyll.yml
@@ -17,4 +17,4 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
* Add _recursive_ write permissions to `/srv/jekyll` in jekyll starter workflow

Fixes issues where the current version produced `permission denied` errors when jekyll needs to create the output directory during build in a private repository.