### PR TITLE
Update the version of tfsec action

### DIFF
--- a/code-scanning/tfsec.yml
+++ b/code-scanning/tfsec.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run tfsec
-        id: run_tfsec
         uses: tfsec/tfsec-sarif-action@bcba1239223e5b6e20680dfcd72e53fbce5aab90
         with:
           sarif_file: tfsec.sarif         
@@ -36,6 +35,3 @@ jobs:
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif  
-
-      - name: Exit with tfsec code
-        run: exit ${{ steps.run_tfsec.outputs.tfsec-return-code}}

--- a/code-scanning/tfsec.yml
+++ b/code-scanning/tfsec.yml
@@ -4,7 +4,6 @@
 # documentation.
 
 name: tfsec
-
 on:
   push:
     branches: [ $default-branch, $protected-branches ]
@@ -12,24 +11,25 @@ on:
     branches: [ $default-branch ]  
   schedule:
     - cron: $cron-weekly
-
 jobs:
   tfsec:
     name: Run tfsec sarif report
     runs-on: ubuntu-latest
-
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
 
       - name: Run tfsec
-        uses: tfsec/tfsec-sarif-action@2ec44316ed27c50d48c931c3c628adc4c8bb1d2b
+        id: run_tfsec
+        uses: tfsec/tfsec-sarif-action@bcba1239223e5b6e20680dfcd72e53fbce5aab90
         with:
           sarif_file: tfsec.sarif         
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif  
+
+      - name: Exit with tfsec code
+        run: exit ${{ steps.run_tfsec.outputs.tfsec-return-code}}


### PR DESCRIPTION
- Updating the version of the action being used
- Using the exit code of tfsec in the exit of the action

<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [x] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [x] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [x] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [x] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [x] Should include comments in the workflow for any parts that are not obvious or could use clarification.

**For _Code Scanning_ workflows, the workflow:**

- [x] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [x] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [x] `name`: Name of the Code Scanning integration.
  - [x] `organization`: Name of the organization producing the Code Scanning integration.
  - [x] `description`: Short description of the Code Scanning integration.
  - [x] `categories`: Array of languages supported by the Code Scanning integration.
  - [x] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [x] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [x] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.
