### PR TITLE
Do not use fail-fast when testing multiple Pythons

### DIFF
--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9]
 


### PR DESCRIPTION
Because the whole purpose of this worflow is to see on which Python the package fails (if it fails), and with `fail-fast` it leads to unnecessary re-runs.