### PR TITLE
Update Python package build and upload example

### DIFF
--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -1,11 +1,16 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [released, prereleased]
 
 jobs:
   deploy:
@@ -21,11 +26,22 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        pip install build
+    - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python -m build
+    - name: Publish DEV package
+      if: "github.event.release.prerelease"
+      # This SHA corresponds to the v1.4.2 release of gh-action-pypi-publish
+      # See: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish package
+      if: "!github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -10,7 +10,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [released, prereleased]
+    types: [published]
 
 jobs:
   deploy:
@@ -28,19 +28,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      run: |
-        python -m build
-    - name: Publish DEV package
-      if: "github.event.release.prerelease"
-      # This SHA corresponds to the v1.4.2 release of gh-action-pypi-publish
-      # See: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+      run: python -m build
     - name: Publish package
-      if: "!github.event.release.prerelease"
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__


### PR DESCRIPTION
## Pre-requisites

- [x] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [x] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [x] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [x] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [x] Should include comments in the workflow for any parts that are not obvious or could use clarification.

**For _CI_ workflows, the workflow:**

- [x] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [x] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
    - **Not Applicable**
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
    - **See summary below describing alternative release types**
- [x] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
    - **Not Applicable**
- [x] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.

## Summary

The [Python Packaging Authority](https://www.pypa.io/en/latest/) (PyPA)--the working group responsible for `pip` and `PyPI`, among other packaging tools--maintains an action for uploading Python packages to PyPI.

This PR makes the following changes to the `python-publish` example:

1. Use the PyPA-maintained PyPI upload action instead of directly interacting with `twine`.
1. Uses [`build`](https://pypa-build.readthedocs.io/en/latest/) to generate the sdist & wheel that will be uploaded to PyPI instead of setuptools, as the former is [PEP-517](https://www.python.org/dev/peps/pep-0517/) compliant.
1. Uses a PyPI token instead of a username and password. Tokens may be scoped down to individual projects on PyPI, whereas the username and password can be used to upload artifacts for any package maintained by the user. As a result, using tokens is more secure.
1. Executes the action only on `release` events of the `released` or `prereleased` types. When a user makes a standard release, this will upload the package to PyPI. When the user makes a pre-release, this will upload the package to the development version of PyPI. This allows for testing the release process without permanently uploading new versions of a package to production PyPI. 

This [example repository](https://github.com/jamescurtin/test-package/actions) was used to demonstrate how this action will be invoked.