### PR TITLE
Use `$cron-daily` for daily schedules

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "21 4 * * *"
+  - cron: $cron-daily
 
 jobs:
   stale:

--- a/automation/stale.yml
+++ b/automation/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+  - cron: $cron-daily
 
 jobs:
   stale:


### PR DESCRIPTION
We have a set of cron helpers to allow start workflows to specify an hourly, daily, or weekly schedule without setting a specific time. These are replaced with a randomized schedule when the starter workflow is selected by a user.