### PR TITLE
fix: only run `deno fmt` and `deno lint` on one job

### DIFF
--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -35,6 +35,7 @@ jobs:
 
       # Uncomment this step to verify the use of 'deno fmt' on each commit.
       # - name: Verify formatting
+      #   if: matrix.os == 'ubuntu-latest'
       #   run: deno fmt --check
 
       - name: Run linter

--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -39,6 +39,7 @@ jobs:
       #   run: deno fmt --check
 
       - name: Run linter
+        if: matrix.os == 'ubuntu-latest'
         run: deno lint
 
       - name: Cache dependencies


### PR DESCRIPTION
The `actions/checkout` action on windows checks out files with `\r\n` line endings instead of preserving them. This causes `deno fmt --check` to fail because the line endings are `\r\n` instead of `\n`.

Regardless, it is better to only run this on one job in order to save CI time. I've made the same change to the lint step.

cc @lucacasonato