### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/sync_ghes.yaml
+++ b/.github/workflows/sync_ghes.yaml
@@ -3,30 +3,31 @@ name: Sync workflows for GHES
 on:
   push:
     branches:
-    - main
+      - main
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-        git config user.email "cschleiden@github.com"
-        git config user.name "GitHub Actions"
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '12'
-    - name: Check starter workflows for GHES compat
-      run: |
-        npm ci
-        npx ts-node-script ./index.ts
-      working-directory: ./script/sync-ghes
-    - run: |
-        git add -A
-        if [ -z "$(git status --porcelain)" ]; then
-          echo "No changes to commit"
-        else
-          git commit -m "Updating GHES workflows"
-        fi
-    - run: git push
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          git config user.email "cschleiden@github.com"
+          git config user.name "GitHub Actions"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+          cache: npm
+      - name: Check starter workflows for GHES compat
+        run: |
+          npm ci
+          npx ts-node-script ./index.ts
+        working-directory: ./script/sync-ghes
+      - run: |
+          git add -A
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to commit"
+          else
+            git commit -m "Updating GHES workflows"
+          fi
+      - run: git push

--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -1,9 +1,8 @@
 name: Validate Data
 
 on:
-  push:
-  pull_request:
-
+  push: null
+  pull_request: null
 jobs:
   validate-data:
     runs-on: ubuntu-latest
@@ -13,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12"
+          cache: npm
 
       - name: Validate workflows
         run: |

--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -1,8 +1,8 @@
 name: Validate Data
 
 on:
-  push: null
-  pull_request: null
+  push:
+  pull_request:
 jobs:
   validate-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
