### PR TITLE
add labeller workflow to triage code scanning PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'code-scanning' label to any changes within 'code-scanning' folder or any subfolders
+code-scanning:
+- code-scanning/**/*

--- a/.github/workflows/labeler-triage.yml
+++ b/.github/workflows/labeler-triage.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds a workflow to automatically triage incoming PRs and add labels.

Labels are defined in `.github/labeler.yml`, and here we add just a pattern to apply the `code-scanning` label.
