### PR TITLE
add specific permissions to the labeler-triage workflow

### DIFF
--- a/.github/workflows/labeler-triage.yml
+++ b/.github/workflows/labeler-triage.yml
@@ -1,4 +1,9 @@
 name: "Pull Request Labeler"
+
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
 - pull_request_target
 


### PR DESCRIPTION
This PR adds specific permissions to the existing `labeler-triage` workflow