### PR TITLE
"deployment" as a category in properties.json

### DIFF
--- a/ci/properties/alibabacloud.properties.json
+++ b/ci/properties/alibabacloud.properties.json
@@ -3,5 +3,5 @@
     "description": "Deploy a container to Alibaba Cloud Container Service for Kubernetes (ACK).",
     "creator": "Alibaba Cloud",
     "iconName": "alibabacloud",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/alibabacloud.properties.json
+++ b/ci/properties/alibabacloud.properties.json
@@ -3,5 +3,5 @@
     "description": "Deploy a container to Alibaba Cloud Container Service for Kubernetes (ACK).",
     "creator": "Alibaba Cloud",
     "iconName": "alibabacloud",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/aws.properties.json
+++ b/ci/properties/aws.properties.json
@@ -3,5 +3,5 @@
     "description": "Deploy a container to an Amazon ECS service powered by AWS Fargate or Amazon EC2.",
     "creator": "Amazon Web Services",
     "iconName": "aws",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/aws.properties.json
+++ b/ci/properties/aws.properties.json
@@ -3,5 +3,5 @@
     "description": "Deploy a container to an Amazon ECS service powered by AWS Fargate or Amazon EC2.",
     "creator": "Amazon Web Services",
     "iconName": "aws",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/azure.properties.json
+++ b/ci/properties/azure.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a Node.js project and deploy it to an Azure Web App.",
     "creator": "Microsoft Azure",
     "iconName": "azure",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/azure.properties.json
+++ b/ci/properties/azure.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a Node.js project and deploy it to an Azure Web App.",
     "creator": "Microsoft Azure",
     "iconName": "azure",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/google.properties.json
+++ b/ci/properties/google.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a docker container, publish it to Google Container Registry, and deploy to GKE.",
     "creator": "Google Cloud",
     "iconName": "googlegke",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/google.properties.json
+++ b/ci/properties/google.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a docker container, publish it to Google Container Registry, and deploy to GKE.",
     "creator": "Google Cloud",
     "iconName": "googlegke",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/ibm.properties.json
+++ b/ci/properties/ibm.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a docker container, publish it to IBM Cloud Container Registry, and deploy to IBM Cloud Kubernetes Service.",
     "creator": "IBM",
     "iconName": "ibm",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/ibm.properties.json
+++ b/ci/properties/ibm.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a docker container, publish it to IBM Cloud Container Registry, and deploy to IBM Cloud Kubernetes Service.",
     "creator": "IBM",
     "iconName": "ibm",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/openshift.properties.json
+++ b/ci/properties/openshift.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a Docker-based project and deploy it to OpenShift.",
     "creator": "Red Hat",
     "iconName": "openshift",
-    "categories": ["Dockerfile","deployment" ]
+    "categories": ["Dockerfile","Deployment" ]
 }

--- a/ci/properties/openshift.properties.json
+++ b/ci/properties/openshift.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a Docker-based project and deploy it to OpenShift.",
     "creator": "Red Hat",
     "iconName": "openshift",
-    "categories": [ "deployment", "Dockerfile" ]
+    "categories": ["Dockerfile","deployment" ]
 }

--- a/ci/properties/openshift.properties.json
+++ b/ci/properties/openshift.properties.json
@@ -3,5 +3,5 @@
     "description": "Build a Docker-based project and deploy it to OpenShift.",
     "creator": "Red Hat",
     "iconName": "openshift",
-    "categories": [ "Dockerfile" ]
+    "categories": [ "deployment", "Dockerfile" ]
 }

--- a/ci/properties/tencent.properties.json
+++ b/ci/properties/tencent.properties.json
@@ -3,5 +3,5 @@
     "description": "This workflow will build a docker container, publish and deploy it to Tencent Kubernetes Engine (TKE).",
     "creator": "Tencent Cloud",
     "iconName": "tencentcloud",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/tencent.properties.json
+++ b/ci/properties/tencent.properties.json
@@ -3,5 +3,5 @@
     "description": "This workflow will build a docker container, publish and deploy it to Tencent Kubernetes Engine (TKE).",
     "creator": "Tencent Cloud",
     "iconName": "tencentcloud",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/ci/properties/terraform.properties.json
+++ b/ci/properties/terraform.properties.json
@@ -3,5 +3,5 @@
     "description": "Set up Terraform CLI in your GitHub Actions workflow.",
     "creator": "HashiCorp",
     "iconName": "terraform",
-    "categories": ["deployment"]
+    "categories": ["Deployment"]
 }

--- a/ci/properties/terraform.properties.json
+++ b/ci/properties/terraform.properties.json
@@ -3,5 +3,5 @@
     "description": "Set up Terraform CLI in your GitHub Actions workflow.",
     "creator": "HashiCorp",
     "iconName": "terraform",
-    "categories": null
+    "categories": ["deployment"]
 }

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -55,10 +55,10 @@ async function checkWorkflows(
         ));
         const iconName: string | undefined = workflowProperties["iconName"];
 
-        const partnerWorkflow = workflowProperties.creator ? partnersSet.has(workflowProperties.creator.toLowerCase()) : false;
+        const isPartnerWorkflow = workflowProperties.creator ? partnersSet.has(workflowProperties.creator.toLowerCase()) : false;
 
         const enabled =
-        !partnerWorkflow &&
+        !isPartnerWorkflow &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {

--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -16,5 +16,15 @@
     "actions/starter-workflows",
     "actions/upload-artifact",
     "actions/upload-release-asset"
+  ],
+  "partners": [
+    "Alibaba Cloud",
+    "Amazon Web Services",
+    "Microsoft Azure",
+    "Google Cloud",
+    "IBM",
+    "Red Hat",
+    "Tencent Cloud",
+    "HashiCorp"
   ]
 }


### PR DESCRIPTION
This is first of the PR series for the issue - https://github.com/github/azure-integration/issues/459
- The PR aims at not changing anything in the [actions/new](https://github.com/github/github/actions/new) experience.
- A new category "deployment" is introduced for the partner templates as a step towards removing the hardcoded list in gh/gh [here](https://github.com/github/github/blob/3f4aa95dfc8646ac732d341c64d853705a2429a3/app/view_models/actions/starter_workflows_view.rb#L11)
- Updating the "sync-ghes" script accordingly. The script makes sure that the partner templates are not synced to GHES (see requirement [here](https://github.com/github/c2c-actions-experience/issues/2848)). This was earlier filtered using the condition `workflowProperties.categories == null`. With this PR, the `categories` field is not null anymore. Hence, I have introduced a list of partner-creators in `settings.json` and the sync-ghes script uses this list to filter out partner templates. 

FYI that the template `openshift` is listed under partner templates in gh/gh [here](https://github.com/github/github/blob/3f4aa95dfc8646ac732d341c64d853705a2429a3/app/view_models/actions/starter_workflows_view.rb#L11). However, it was not filtered out in the `sync-ghes` script for being partner template [here](https://github.com/actions/starter-workflows/blob/216e9acdacbbd16cfdf1ec30c3bc98bcdefb7580/script/sync-ghes/index.ts#L55). Anyway, the template was filtered out in a later step and is not synced to GHES. I have included the creator for `openshift` and have filtered it out in the step for partner templates. 