### PR TITLE
Add a descriptive comment into stale.yml

### DIFF
--- a/automation/stale.yml
+++ b/automation/stale.yml
@@ -1,3 +1,8 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
 on:


### PR DESCRIPTION
This PR adds a descriptive comment int "stale.yml" so user know what this does and how adjust.

 because user's can come to this workflow as a template
directly from their issue page and this extra 
This PR adds a descriptive comment int "stale.yml" so user know what this does and how adjust.

This was a suggestion from @Carmel-S and @jenschelkopf and we think this can be helpful because users can come to this workflow as a template directly from their issue page and this extra content will help them understand what this is.

![image](https://user-images.githubusercontent.com/771411/131395805-efc1ae47-9a90-4aa3-b39b-74178e2b02ce.png)