### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/label-feature.yml
+++ b/.github/workflows/label-feature.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Close Issue

--- a/.github/workflows/label-support.yml
+++ b/.github/workflows/label-support.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Close Issue

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stale:
 
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync_ghes.yaml
+++ b/.github/workflows/sync_ghes.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   sync:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   validate-data:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows. 

## Background

I am the founder of [Step Security](https://www.stepsecurity.io), and have implemented a GitHub App to automatically restrict permissions for the `GitHUB_TOKEN` in workflows. I am trying it out on open source repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. Thanks!