### PR TITLE
add codeql workflow to ghes branch

### DIFF
--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -2,7 +2,8 @@
   "folders": [
     "../../ci",
     "../../automation",
-    "../../deployments"
+    "../../deployments",
+    "../../code-scanning"
   ],
   "enabledActions": [
     "actions/checkout",
@@ -16,7 +17,8 @@
     "actions/stale",
     "actions/starter-workflows",
     "actions/upload-artifact",
-    "actions/upload-release-asset"
+    "actions/upload-release-asset",
+    "github/codeql-action"
   ],
   "partners": [
     "Alibaba Cloud",


### PR DESCRIPTION
This PR explicitly adds the CodeQL example workflow for Code Scanning to the process that maintains the GHES branch.

This workflow is dependent on actions from `https://github.com/github/codeql-action`, a copy of which is independently made available on GHES.