### PR TITLE
Nickfyson/add codeql to ghes

### DIFF
--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -58,7 +58,7 @@ async function checkWorkflows(
         const isPartnerWorkflow = workflowProperties.creator ? partnersSet.has(workflowProperties.creator.toLowerCase()) : false;
 
         const enabled =
-        !isPartnerWorkflow &&
+          !isPartnerWorkflow &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {
@@ -104,7 +104,8 @@ async function checkWorkflow(
         if (!!step.uses) {
           // Check if allowed action
           const [actionName, _] = step.uses.split("@");
-          if (!enabledActionsSet.has(actionName.toLowerCase())) {
+          const actionNwo = actionName.split("/").slice(0, 2).join("/");
+          if (!enabledActionsSet.has(actionNwo.toLowerCase())) {
             console.info(
               `Workflow ${workflowPath} uses '${actionName}' which is not supported for GHES.`
             );

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -45,7 +45,7 @@ async function checkWorkflows(
     });
 
     for (const e of dir) {
-      if (e.isFile()) {
+      if (e.isFile() && extname(e.name) === ".yml") {
         const workflowFilePath = join(folder, e.name);
         const workflowId = basename(e.name, extname(e.name));
         const workflowProperties: WorkflowProperties = require(join(

--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -2,7 +2,8 @@
   "folders": [
     "../../ci",
     "../../automation",
-    "../../deployments"
+    "../../deployments",
+    "../../code-scanning"
   ],
   "enabledActions": [
     "actions/checkout",
@@ -16,7 +17,8 @@
     "actions/stale",
     "actions/starter-workflows",
     "actions/upload-artifact",
-    "actions/upload-release-asset"
+    "actions/upload-release-asset",
+    "github/codeql-action"
   ],
   "partners": [
     "Alibaba Cloud",


### PR DESCRIPTION
Second take on adapting the GHES sync workflow to include the CodeQL workflow (see the reverted PR https://github.com/actions/starter-workflows/pull/1077).

Running the workflow on this PR still ultimately fails (due to not running on the main branch), but crucially it does now successfully include CodeQL...

https://github.com/actions/starter-workflows/runs/3542982057?check_suite_focus=true#step:5:65

And _not_ include any of the other code scanning workflows...

https://github.com/actions/starter-workflows/runs/3542982057?check_suite_focus=true#step:5:97
