### PR TITLE
Added support for Java Frameworks, Spring and JSF to CI Templates.

### DIFF
--- a/ci/properties/gradle-publish.properties.json
+++ b/ci/properties/gradle-publish.properties.json
@@ -2,5 +2,5 @@
     "name": "Publish Java Package with Gradle",
     "description": "Build a Java Package using Gradle and publish to GitHub Packages.",
     "iconName": "gradle",
-    "categories": ["Java", "Gradle"]
+    "categories": ["Java", "Gradle", "Spring", "JSF"]
 }

--- a/ci/properties/gradle.properties.json
+++ b/ci/properties/gradle.properties.json
@@ -2,5 +2,5 @@
     "name": "Java with Gradle",
     "description": "Build and test a Java project using a Gradle wrapper script.",
     "iconName": "gradle",
-    "categories": ["Java", "Gradle"]
+    "categories": ["Java", "Gradle", "Spring", "JSF"]
 }

--- a/ci/properties/maven-publish.properties.json
+++ b/ci/properties/maven-publish.properties.json
@@ -2,5 +2,5 @@
     "name": "Publish Java Package with Maven",
     "description": "Build a Java Package using Maven and publish to GitHub Packages.",
     "iconName": "maven",
-    "categories": ["Java", "Maven"]
+    "categories": ["Java", "Maven", "Spring", "JSF"]
 }

--- a/ci/properties/maven.properties.json
+++ b/ci/properties/maven.properties.json
@@ -2,5 +2,5 @@
     "name": "Java with Maven",
     "description": "Build and test a Java project with Apache Maven.",
     "iconName": "maven",
-    "categories": ["Java", "Maven"]
+    "categories": ["Java", "Maven", "Spring", "JSF"]
 }


### PR DESCRIPTION
As part of extending the support for java-based tech stack templates, this PR aims to add support for Spring and JSF frameworks. Doing this will help bubble up relevant templates for Spring/JSF based repositories.
These frameworks need no commands of their own to build/deploy their respective repo as it depends on the build tool(Maven/Gradle) instead. So, Maven, Gradle templates are the most relevant template currently available for these two tech stacks. Adding these two tech stacks to the categories field in these build tool templates will bubble up these templates for a repo containing Spring/JSF frameworks in the starter workflow experience.

As a follow-up to this, we'll be adding the detection for these frameworks to the [Scout](https://github.com/github/scout/blob/main/lib/scout/tech_stacks.yml) project.