### PR TITLE
Update OpenShift workflow to use GHCR by default (#6)

### DIFF
--- a/deployments/openshift.yml
+++ b/deployments/openshift.yml
@@ -3,61 +3,57 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-### The OpenShift Starter workflow will:
+# 💁 The OpenShift Starter workflow will:
 # - Checkout your repository
-# - Perform a Docker build
-# - Push the built image to an image registry
+# - Perform a container image build
+# - Push the built image to the GitHub Container Registry (GHCR)
 # - Log in to your OpenShift cluster
-# - Create an OpenShift app from the image and expose it to the internet.
+# - Create an OpenShift app from the image and expose it to the internet
 
-### Before you begin:
-# - Have write access to a container image registry such as quay.io or Dockerhub.
-# - Have access to an OpenShift cluster.
-#   - For instructions to get started with OpenShift see https://www.openshift.com/try
-# - The project you wish to add this workflow to should have a Dockerfile.
-#   - If you don't have a Dockerfile at the repository root, see the buildah-build step.
-#   - Builds from scratch are also available, but require more configuration.
+# ℹ️ Configure your repository and the workflow with the following steps:
+# 1. Have access to an OpenShift cluster. Refer to https://www.openshift.com/try
+# 2. Create the OPENSHIFT_SERVER and OPENSHIFT_TOKEN repository secrets. Refer to:
+#   - https://github.com/redhat-actions/oc-login#readme
+#   - https://docs.github.com/en/actions/reference/encrypted-secrets
+#   - https://cli.github.com/manual/gh_secret_set
+# 3. (Optional) Edit the top-level 'env' section as marked with '🖊️' if the defaults are not suitable for your project.
+# 4. (Optional) Edit the build-image step to build your project.
+#    The default build type is by using a Dockerfile at the root of the repository,
+#    but can be replaced with a different file, a source-to-image build, or a step-by-step buildah build.
+# 5. Commit and push the workflow file to your default branch to trigger a workflow run.
 
-### To get the workflow running:
-# 1. Add this workflow to your repository.
-# 2. Edit the top-level 'env' section, which contains a list of environment variables that must be configured.
-# 3. Create the secrets referenced in the 'env' section under your repository Settings.
-# 4. Edit the 'branches' in the 'on' section to trigger the workflow on a push to your branch.
-# 5. Commit and push your changes.
-
-# For a more sophisticated example, see https://github.com/redhat-actions/spring-petclinic/blob/main/.github/workflows/petclinic-sample.yaml
-# Also see our GitHub organization, https://github.com/redhat-actions/
-# ▶️ See a video of how to set up this workflow at https://www.youtube.com/watch?v=6hgBO-1pKho
+# 👋 Visit our GitHub organization at https://github.com/redhat-actions/ to see our actions and provide feedback.
 
 name: OpenShift
 
-# ⬇️  Modify the fields marked with ⬇️ to fit your project, and create any secrets that are referenced.
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
 env:
-  # ⬇️ EDIT with your registry and registry path.
-  REGISTRY: quay.io/<username>
-  # ⬇️ EDIT with your registry username.
-  REGISTRY_USER: <username>
-  REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-
-  # ⬇️ EDIT to log into your OpenShift cluster and set up the context.
+  # 🖊️ EDIT your repository secrets to log into your OpenShift cluster and set up the context.
   # See https://github.com/redhat-actions/oc-login#readme for how to retrieve these values.
+  # To get a permanent token, refer to https://github.com/redhat-actions/oc-login/wiki/Using-a-Service-Account-for-GitHub-Actions
   OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
   OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
-
-  # ⬇️ EDIT with any additional port your application should expose.
-  # By default, oc new-app action creates a service to the image's lowest numeric exposed port.
-  APP_PORT: ""
-
-  # ⬇️ EDIT if you wish to set the kube context's namespace after login. Leave blank to use the default namespace.
+  # 🖊️ EDIT to set the kube context's namespace after login. Leave blank to use your user's default namespace.
   OPENSHIFT_NAMESPACE: ""
 
-  # If you wish to manually provide the APP_NAME and TAG, set them here, otherwise they will be auto-detected.
+  # 🖊️ EDIT to set a name for your OpenShift app, or a default one will be generated below.
   APP_NAME: ""
-  TAG: ""
+
+  # 🖊️ EDIT with the port your application should be accessible on.
+  # If the container image exposes *exactly one* port, this can be left blank.
+  # Refer to the 'port' input of https://github.com/redhat-actions/oc-new-app
+  APP_PORT: ""
+
+  # 🖊️ EDIT to change the image registry settings.
+  # Registries such as GHCR, Quay.io, and Docker Hub are supported.
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_REGISTRY_USER: ${{ github.actor }}
+  IMAGE_REGISTRY_PASSWORD: ${{ github.token }}
+
+  # 🖊️ EDIT to specify custom tags for the container image, or default tags will be generated below.
+  IMAGE_TAGS: ""
 
 on:
-  # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
   push:
     # Edit to the branch(es) you want to build and deploy on each push.
     branches: [ $default-branch ]
@@ -65,32 +61,40 @@ on:
 jobs:
   openshift-ci-cd:
     name: Build and deploy to OpenShift
+    # ubuntu-20.04 can also be used.
     runs-on: ubuntu-18.04
     environment: production
 
     outputs:
-        ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
-        SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}
+      ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
+      SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}
 
     steps:
-    - name: Check if secrets exists
+    - name: Check for required secrets
       uses: actions/github-script@v3
       with:
         script: |
           const secrets = {
-            REGISTRY_PASSWORD: `${{ secrets.REGISTRY_PASSWORD }}`,
             OPENSHIFT_SERVER: `${{ secrets.OPENSHIFT_SERVER }}`,
             OPENSHIFT_TOKEN: `${{ secrets.OPENSHIFT_TOKEN }}`,
           };
 
+          const GHCR = "ghcr.io";
+          if (`${{ env.IMAGE_REGISTRY }}`.startsWith(GHCR)) {
+            core.info(`Image registry is ${GHCR} - no registry password required`);
+          }
+          else {
+            core.info("A registry password is required");
+            secrets["IMAGE_REGISTRY_PASSWORD"] = `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`;
+          }
+
           const missingSecrets = Object.entries(secrets).filter(([ name, value ]) => {
             if (value.length === 0) {
-              core.warning(`Secret "${name}" is not set`);
+              core.error(`Secret "${name}" is not set`);
               return true;
             }
             core.info(`✔️ Secret "${name}" is set`);
             return false;
-
           });
 
           if (missingSecrets.length > 0) {
@@ -104,48 +108,50 @@ jobs:
             core.info(`✅ All the required secrets are set`);
           }
 
-    - uses: actions/checkout@v2
+    - name: Check out repository
+      uses: actions/checkout@v2
 
     - name: Determine app name
       if: env.APP_NAME == ''
       run: |
         echo "APP_NAME=$(basename $PWD)" | tee -a $GITHUB_ENV
 
-    - name: Determine tag
-      if: env.TAG == ''
+    - name: Determine image tags
+      if: env.IMAGE_TAGS == ''
       run: |
-        echo "TAG=${GITHUB_SHA::7}" | tee -a $GITHUB_ENV
+        echo "IMAGE_TAGS=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
     # https://github.com/redhat-actions/buildah-build#readme
     - name: Build from Dockerfile
-      id: image-build
+      id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.APP_NAME }}
-        tags: ${{ env.TAG }}
-        # If you don't have a dockerfile, see:
-        # https://github.com/redhat-actions/buildah-build#scratch-build-inputs
-        # Otherwise, point this to your Dockerfile relative to the repository root.
+        tags: ${{ env.IMAGE_TAGS }}
+
+        # If you don't have a Dockerfile/Containerfile, refer to https://github.com/redhat-actions/buildah-build#scratch-build-inputs
+        # Or, perform a source-to-image build using https://github.com/redhat-actions/s2i-build
+        # Otherwise, point this to your Dockerfile/Containerfile relative to the repository root.
         dockerfiles: |
           ./Dockerfile
 
     # https://github.com/redhat-actions/push-to-registry#readme
     - name: Push to registry
-      id: push-to-registry
+      id: push-image
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.image-build.outputs.image }}
-        tags: ${{ steps.image-build.outputs.tags }}
-        registry: ${{ env.REGISTRY }}
-        username: ${{ env.REGISTRY_USER }}
-        password: ${{ env.REGISTRY_PASSWORD }}
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ env.IMAGE_REGISTRY_USER }}
+        password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
 
-    # The path the image was pushed to is now stored in ${{ steps.push-to-registry.outputs.registry-path }}
+    # The path the image was pushed to is now stored in ${{ steps.push-image.outputs.registry-path }}
 
-    # oc-login works on all platforms, but oc must be installed first.
-    # The GitHub Ubuntu runner already includes oc.
-    # Otherwise, https://github.com/redhat-actions/openshift-tools-installer can be used to install oc,
-    # as well as many other tools.
+    - name: Install oc
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: 4
 
     # https://github.com/redhat-actions/oc-login#readme
     - name: Log in to OpenShift
@@ -163,18 +169,19 @@ jobs:
       uses: redhat-actions/oc-new-app@v1
       with:
         app_name: ${{ env.APP_NAME }}
-        image: ${{ steps.push-to-registry.outputs.registry-path }}
+        image: ${{ steps.push-image.outputs.registry-path }}
         namespace: ${{ env.OPENSHIFT_NAMESPACE }}
         port: ${{ env.APP_PORT }}
 
-    - name: View application route
+    - name: Print application URL
+      env:
+        ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
+        SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}
       run: |
         [[ -n ${{ env.ROUTE }} ]] || (echo "Determining application route failed in previous step"; exit 1)
+        echo
         echo "======================== Your application is available at: ========================"
         echo ${{ env.ROUTE }}
         echo "==================================================================================="
         echo
         echo "Your app can be taken down with: \"oc delete all --selector='${{ env.SELECTOR }}'\""
-      env:
-        ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
-        SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}

--- a/deployments/openshift.yml
+++ b/deployments/openshift.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: Check for required secrets
-      uses: actions/github-script@v3
+      uses: actions/github-script@v4
       with:
         script: |
           const secrets = {


### PR DESCRIPTION
- Simplifies required configuration since a registry account is now
  optional
- Update a variety of comments
- Use tools-installer to install oc
- Other small changes towards a better UX

Signed-off-by: Tim Etchells <tetchel@gmail.com>

<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [x] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.

**For _CI_ workflows, the workflow:**

- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [ ] `name`: Name of the Code Scanning integration.
  - [ ] `organization`: Name of the organization producing the Code Scanning integration.
  - [ ] `description`: Short description of the Code Scanning integration.
  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [ ] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Automation and CI workflows cannot be dependent on a paid service or product.
