### PR TITLE
add `Vue` to nodejs props

### DIFF
--- a/ci/properties/node.js.properties.json
+++ b/ci/properties/node.js.properties.json
@@ -2,5 +2,5 @@
     "name": "Node.js",
     "description": "Build and test a Node.js project with npm.",
     "iconName": "nodejs",
-    "categories": ["Continuous integration", "JavaScript", "npm", "React", "Angular"]
+    "categories": ["Continuous integration", "JavaScript", "npm", "React", "Angular", "Vue"]
 }


### PR DESCRIPTION
The purpose of this PR is to be bubble up the `node.js` template for `Vue` based templates. `Vue` today is being detected by [linguist].(https://github.com/github/linguist/blob/971e152fabca12e0ad386833eecb7b15e312a09f/lib/linguist/languages.yml#L6438)

Using `npm` commands for build makes sure we take no global dependencies, and everything defined in `scripts` from `package.json` gets executed. (_Source_: https://stackoverflow.com/questions/42936588/which-command-do-i-use-to-generate-the-build-of-a-vue-app)