### PR TITLE
fix: package.json reference on Data Factory CI removed

### DIFF
--- a/ci/azure-data-factory.yml
+++ b/ci/azure-data-factory.yml
@@ -1,15 +1,3 @@
-# Sample workflow to validate Azure Data Factory resources and export its ARM template as an artifact
-# Note: Ensure you have the following package.json in the same directory of your ADF resources
-
-# {
-#     "scripts":{
-#         "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index"
-#     },
-#     "dependencies":{
-#         "@microsoft/azure-data-factory-utilities":"^0.1.5"
-#     }
-# } 
-
 name: Data Factory CI
 
 on:
@@ -29,7 +17,7 @@ jobs:
       - name: Validate
         uses: Azure/data-factory-validate-action@v1.1.3
         # with:
-        #   path: <data-factory-dir> # replace by the folder that contains the Data Factory resources and the package.json
+        #   path: <data-factory-dir> # replace by the folder that contains the Data Factory resources
 
       # Generate the ARM template into the destination folder, which is the same as selecting "Publish" from the UX.
       # The ARM template generated isn't published to the live version of the factory.
@@ -37,7 +25,7 @@ jobs:
         id: export
         uses: Azure/data-factory-export-action@v1.1.0
         # with:
-        #   path: <data-factory-dir> # replace by the folder that contains the Data Factory resources and the package.json
+        #   path: <data-factory-dir> # replace by the folder that contains the Data Factory resources
 
       - name: Publish artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR fixes the references to `package.json` on the Data Factory CI workflow as it's not needed anymore. Latest versions of `data-factory-validate-action` and `data-factory-export-action` embed the data factory utilities dependencies, removing the requirement to have this file on the repo.