### PR TITLE
Updating workflows to use new GITHUB_REF_NAME variable

### DIFF
--- a/deployments/google.yml
+++ b/deployments/google.yml
@@ -58,7 +58,7 @@ jobs:
         docker build \
           --tag "gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA" \
           --build-arg GITHUB_SHA="$GITHUB_SHA" \
-          --build-arg GITHUB_REF="$GITHUB_REF" \
+          --build-arg GITHUB_REF="$GITHUB_REF_NAME" \
           .
 
     # Push the Docker image to Google Container Registry

--- a/deployments/ibm.yml
+++ b/deployments/ibm.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         docker build -t "$REGISTRY_HOSTNAME"/"$ICR_NAMESPACE"/"$IMAGE_NAME":"$GITHUB_SHA" \
           --build-arg GITHUB_SHA="$GITHUB_SHA" \
-          --build-arg GITHUB_REF="$GITHUB_REF" .
+          --build-arg GITHUB_REF="$GITHUB_REF_NAME" .
 
     # Push the image to IBM Container Registry
     - name: Push the image to ICR


### PR DESCRIPTION
Don't merge until https://github.com/github/c2c-actions-runtime/issues/1490 ships.