### PR TITLE
Add 'fetch-depth: 0' to 'checkout' step in 'ci/gradle' workflow

### DIFF
--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
This fixes the error with gradle using `HEAD^` commit. Here's an example error log from the gradle run step:

```
Run /usr/bin/git checkout origin/master && ./gradlew clean test
Note: switching to 'origin/master'.
...
HEAD is now at 0e680bc Add test

Downloading https://services.gradle.org/distributions/gradle-6.9-all.zip

....

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
Unexpected error while parsing HEAD commit: Missing commit b4569d6e4d8174bc166c58b9bf1d6abb9710ef1d
> Missing commit b4569d6e4d8174bc166c58b9bf1d6abb9710ef1d
```

The commit `b4569d6e4d8174bc166c58b9bf1d6abb9710ef1d` here is the second from the HEAD.

Here's the sample actions build with this issue: https://github.com/serpro69/kotlin-faker/actions/runs/1349130939