### PR TITLE
Add ruby and update CodeQL workflow

### DIFF
--- a/code-scanning/codeql.yml
+++ b/code-scanning/codeql.yml
@@ -34,8 +34,7 @@ jobs:
       matrix:
         language: [ $detected-codeql-languages ]
         # CodeQL supports [ $supported-codeql-languages ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository

--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -1,7 +1,7 @@
 {
     "name": "CodeQL Analysis",
     "creator": "GitHub",
-    "description": "Security analysis from GitHub for C, C++, C#, Java, JavaScript, TypeScript, Python, and Go developers.",
+    "description": "Security analysis from GitHub for C, C++, C#, Java, JavaScript, TypeScript, Python, Go and Ruby developers. \n ",
     "iconName": "octicon mark-github",
-    "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python"]
+    "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
 }

--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -1,7 +1,7 @@
 {
     "name": "CodeQL Analysis",
     "creator": "GitHub",
-    "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python and Ruby developers.",
+    "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python, and Ruby developers.",
     "iconName": "octicon mark-github",
     "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
 }

--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -3,5 +3,5 @@
     "creator": "GitHub",
     "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python, and Ruby developers.",
     "iconName": "octicon mark-github",
-    "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
+    "categories": ["Code Scanning", "C", "C++", "C#", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
 }

--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -1,7 +1,7 @@
 {
     "name": "CodeQL Analysis",
     "creator": "GitHub",
-    "description": "Security analysis from GitHub for C, C++, C#, Java, JavaScript, TypeScript, Python, Go and Ruby developers. \n ",
+    "description": "Security analysis from GitHub for C, C++, C#, Java, JavaScript, TypeScript, Python, Go and Ruby developers.",
     "iconName": "octicon mark-github",
     "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
 }

--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -1,7 +1,7 @@
 {
     "name": "CodeQL Analysis",
     "creator": "GitHub",
-    "description": "Security analysis from GitHub for C, C++, C#, Java, JavaScript, TypeScript, Python, Go and Ruby developers.",
+    "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python and Ruby developers.",
     "iconName": "octicon mark-github",
     "categories": ["Code Scanning", "C", "C#", "C++", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
 }


### PR DESCRIPTION
As part of the new launch of the beta version of ruby for CodeQL, we need to update the properties of the tile, and change the support link in the workflow file.