### PR TITLE
Fixed typo in Microsoft C++ Code Analysis workflow.

### DIFF
--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -37,7 +37,7 @@ jobs:
       #   run: cmake --build ${{ env.build }}
 
       - name: Initialize MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@502db28262ba134c9a621d5a509b9f7e696c99b6
+        uses: microsoft/msvc-code-analysis-action@04825f6d9e00f87422d6bf04e1a38b1f3ed60d99
         # Provide a unique ID to access the sarif output path
         id: run-analysis
         with:


### PR DESCRIPTION
There was a typo in the default ruleset used in the Microsoft C++ Code Analysis action. It currently points to a non-existent ruleset which will cause the workflow to always fail (microsoft/msvc-code-analysis-action#4)  .

No functional change was made to the action (updated workflow in readme) but the commit SHA was updated for good measure.
      