### PR TITLE
actions/setup-haskell → haskell/actions/setup

### DIFF
--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       with:
         ghc-version: '8.10.3'
         cabal-version: '3.2'


### PR DESCRIPTION
[setup-haskell](https://github.com/actions/setup-haskell) (archived) says

> **Please note**: This repository is currently unmaintained by a team of developers at GitHub. The repository is here and you can use it as an example, or in Actions. However please be aware that we are not going to be updating issues or pull requests on this repository.
>
> **Maintained forks**:
>
> - haskell/actions
