### PR TITLE
chore: split npm publish into 2 workflows

### DIFF
--- a/ci/npm-publish-github-packages.yml
+++ b/ci/npm-publish-github-packages.yml
@@ -18,16 +18,19 @@ jobs:
       - run: npm ci
       - run: npm test
 
-  publish-npm:
+  publish-gpr:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-          registry-url: https://registry.npmjs.org/
+          registry-url: $registry-url(npm)
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/ci/properties/npm-publish-github-packages.properties.json
+++ b/ci/properties/npm-publish-github-packages.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Publish Node.js Package to GitHub Packages",
+    "description": "Publishes a Node.js package to GitHub Packages.",
+    "iconName": "node-package-transparent",
+    "categories": ["Continuous integration", "JavaScript", "npm"]
+}

--- a/ci/properties/npm-publish.properties.json
+++ b/ci/properties/npm-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Publish Node.js Package",
-    "description": "Publishes a Node.js package to npm and GitHub Packages.",
+    "description": "Publishes a Node.js package to npm.",
     "iconName": "node-package-transparent",
     "categories": ["Continuous integration", "JavaScript", "npm"]
 }


### PR DESCRIPTION
Currently we suggest that folks dual publish to both npm + gpr.

There are a large number of edge cases related to doing this and IMHO it is
not the best practice. Let's make two separate workflows.
