### PR TITLE
Use Node 14 in the starter workflow, not Node 10

### DIFF
--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -26,7 +26,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: '10.x'                # set this to the node version to use
+  NODE_VERSION: '14.x'                # set this to the node version to use
 
 jobs:
   build:


### PR DESCRIPTION
<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [X] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

Node 10 isn't even in maintenance mode any more! I should have caught this sooner. 

https://nodejs.org/en/about/releases/ 