### PR TITLE
Fix version of `denoland/setup-deno`

### DIFF
--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -23,8 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        # uses: denoland/setup-deno@v1
-        uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e9833173669
+        uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 

--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366
         with:
           deno-version: v1.x
 


### PR DESCRIPTION
The version of the `denoland/setup-deno` action is a wierd hash that doesn't work. Instead using `v1` from the marketplace listing seems to work.