### PR TITLE
Fix some workflows not being excluded from Enterprise syncing.

### DIFF
--- a/code-scanning/properties/detekt.properties.json
+++ b/code-scanning/properties/detekt.properties.json
@@ -3,7 +3,6 @@
     "creator": "Detekt",
     "description": "Static code analysis for Kotlin",
     "iconName": "detekt",
-    "categories": ["Code Scanning", "Kotlin"]
+    "categories": ["Code Scanning", "Kotlin"],
+    "enterprise": false
 }
-
-    

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -21,6 +21,8 @@ interface WorkflowProperties {
   categories: string[] | null;
 
   creator?: string;
+
+  enterprise?: boolean;
 }
 
 interface WorkflowsCheckResult {
@@ -59,6 +61,7 @@ async function checkWorkflows(
 
         const enabled =
           !isPartnerWorkflow &&
+          workflowProperties.enterprise !== false &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {


### PR DESCRIPTION
This allows manually excluding starter workflows from being bundled into an Enterprise Server release and removes a workflow that was mistakenly.

A lot of starter workflows won't work on Enterprise Server without specific tweaks to ensure it will work on self-hosted runners and if the runner is air-gapped. These starter workflows are currently detected based on the Actions they use, but in some cases there are workflows that don't include any Actions but use shell scripts to make outbound calls that might fail in an Enterprise Server environment.

In these cases it's useful to be able to manually specify that a workflow shouldn't be included in Enterprise Server. This adds the ability to do that.