### PR TITLE
Update `download-artifact` and `upload-artifact` from `v2` to `v3`

### DIFF
--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -109,7 +109,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MSIX Package
         path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Upload SARIF file as an Artifact to download and view
       # - name: Upload SARIF as an Artifact
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@v3
       #   with:
       #     name: sarif-file
       #     path: ${{ steps.run-analysis.outputs.sarif }}

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -79,7 +79,7 @@ jobs:
           license: ${{ secrets.XANITIZER_LICENSE }}
 
       # Archiving the findings list reports
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Xanitizer-Reports
           path: |

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: .net-app
 

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -57,7 +57,7 @@ jobs:
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: .net-app
           path: ${{env.DOTNET_ROOT}}/myapp

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -60,7 +60,7 @@ jobs:
     
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -46,7 +46,7 @@ jobs:
         run: mvn clean install
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: java-app
           path: '${{ github.workspace }}/target/*.jar'

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: node-app
 

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -47,7 +47,7 @@ jobs:
         npm run test --if-present
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: node-app
         path: .

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: php-app
 

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -68,7 +68,7 @@ jobs:
         run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: php-app
           path: .

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -53,7 +53,7 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
       
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: python-app
           path: |

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: python-app
           path: .


### PR DESCRIPTION
The first-party GitHub actions `actions/upload-artifact` (([link](https://github.com/actions/upload-artifact)) and `actions/download-artifact` ([link](https://github.com/actions/download-artifact)) have had a major version bump. Updating the versions here.

