### PR TITLE
Remove creator property from rust-clippy

### DIFF
--- a/code-scanning/properties/rust-clippy.properties.json
+++ b/code-scanning/properties/rust-clippy.properties.json
@@ -1,6 +1,5 @@
 {
     "name": "rust-clippy",
-    "creator": "Rust",
     "description": "A collection of lints to catch common mistakes and improve your Rust code.",
     "iconName": "rust",
     "categories": [


### PR DESCRIPTION
This is owned by @josepalafox's BD team in GitHub.

