### PR TITLE
Add Actions team as CODEOWNERS for code-scanning starter workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @actions/starter-workflows
 
-/code-scanning/ @actions/advanced-security-code-scanning
+/code-scanning/ @actions/advanced-security-code-scanning @actions/starter-workflows


### PR DESCRIPTION
Actions team is the primary reviewer for code-scanning starter workflows as well.