### PR TITLE
Update docker/build-push-action

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -72,7 +72,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Switching the Docker Publish starter workflow to https://github.com/docker/build-push-action/releases/tag/v2.10.0 (pinned as https://github.com/docker/build-push-action/commit/ac9327eae2b366085ac7f6a2d02df8aa8ead720a) to pick up https://github.com/docker/build-push-action/pull/569. Amends #1452 by @dlorenc. Fixes #1519 from what I can tell in one repository I tried. (Is there some sort of testbed in which changes to starter workflows are verified?)

Full diff https://github.com/docker/build-push-action/compare/ad44023a93711e3deb337508980b4b5e9bcdc5dc...ac9327eae2b366085ac7f6a2d02df8aa8ead720a includes a lot of other changes which I know nothing about.