### PR TITLE
Fix link to `code-scanning` directory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ It is not:
 - [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
 - [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
 - [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
-- [ ] Should specify least priviledge [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully. 
+- [ ] Should specify least priviledge [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.
 
 **For _CI_ workflows, the workflow:**
 
@@ -38,7 +38,7 @@ It is not:
 
 **For _Code Scanning_ workflows, the workflow:**
 
-- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/ci).
+- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
 - [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
   - [ ] `name`: Name of the Code Scanning integration.
   - [ ] `organization`: Name of the organization producing the Code Scanning integration.


### PR DESCRIPTION
Changed https://github.com/actions/starter-workflows/tree/main/ci to https://github.com/actions/starter-workflows/tree/main/code-scanning