### PR TITLE
Fix the missing `on` trigger for AKS Kompose

### DIFF
--- a/deployments/azure-kubernetes-service-kompose.yml
+++ b/deployments/azure-kubernetes-service-kompose.yml
@@ -31,6 +31,12 @@
 
 name: Build and deploy an app to AKS with Kompose
 
+on:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
 env:
   AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
   CONTAINER_NAME: "your-container-name"


### PR DESCRIPTION
Trigger spec is missing from AKS kompose starter workflow and that even shows up as error in the workflow editor.