### PR TITLE
Update tfsec.yml

### DIFF
--- a/code-scanning/tfsec.yml
+++ b/code-scanning/tfsec.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run tfsec
-        uses: tfsec/tfsec-sarif-action@9a83b5c3524f825c020e356335855741fd02745f
+        uses: aquasecurity/tfsec-sarif-action@9a83b5c3524f825c020e356335855741fd02745f
         with:
           sarif_file: tfsec.sarif         
 


### PR DESCRIPTION
The org name for `tfsec` is now `aquasecurity`. This changes the action name.

[github.com/tfsec/tfsec-sarif-action](https://github.com/tfsec/tfsec-sarif-action) ➡️ [github.com/aquasecurity/tfsec-sarif-action](https://github.com/aquasecurity/tfsec-sarif-action)