### PR TITLE
fix: docker-publish.yml cosign command line args when multiple tags are present

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -90,4 +90,4 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
With scheduled builds the output docker image has two tags - branch name (eg, main) and nightly.

The current template is passing these as a single argument into the cosign sign command. This is causing failures of the workflow when run with a scheduled trigger.

This change splits them using xargs and runs multiple cosign commands, one for each tag.

Tested by running against one of my own repos, eg: https://github.com/jamesmoore/mp3info/runs/7087514897?check_suite_focus=true#step:8:2