### PR TITLE
Update dotnet.yml

### DIFF
--- a/ci/dotnet.yml
+++ b/ci/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Updated the .NET starter workflow to use .NET 6 instead of .NET 5, since .NET 5 has reached end of support.