### PR TITLE
Build with Jekyll in production environment

### DIFF
--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v1
-      - run: bundle exec jekyll build --baseurl ${{ steps.pages.outputs.base_path }} # defaults output to '/_site'
+      - run: JEKYLL_ENV=production bundle exec jekyll build --baseurl ${{ steps.pages.outputs.base_path }} # defaults output to '/_site'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1 # This will automatically upload an artifact from the '/_site' directory
 


### PR DESCRIPTION
The default value for `JEKYLL_ENV` is development. Therefore if you omit `JEKYLL_ENV` from the build arguments, the default value will be `JEKYLL_ENV=development`.  Read more: https://jekyllrb.com/docs/configuration/environments/
