### PR TITLE
Fix PR auto assign

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,6 +1,6 @@
 name: 'Auto Assign'
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
Fixes PR auto assign by changing trigger on `pull_request` to `pull_request_target` so that explicit approval is not needed for workflow to run.