### PR TITLE
Add pages to ghes sync script

### DIFF
--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -2,13 +2,17 @@
   "folders": [
     "../../ci",
     "../../automation",
-    "../../code-scanning"
+    "../../code-scanning",
+    "../../pages"
   ],
   "enabledActions": [
     "actions/checkout",
+    "actions/configure-pages",
     "actions/create-release",
     "actions/delete-package-versions",
+    "actions/deploy-pages",
     "actions/download-artifact",
+    "actions/jekyll-build-pages",
     "actions/setup-dotnet",
     "actions/setup-go",
     "actions/setup-java",
@@ -16,6 +20,7 @@
     "actions/stale",
     "actions/starter-workflows",
     "actions/upload-artifact",
+    "actions/upload-pages-artifact".
     "actions/upload-release-asset",
     "github/codeql-action"
   ],

--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -20,7 +20,7 @@
     "actions/stale",
     "actions/starter-workflows",
     "actions/upload-artifact",
-    "actions/upload-pages-artifact".
+    "actions/upload-pages-artifact",
     "actions/upload-release-asset",
     "github/codeql-action"
   ],


### PR DESCRIPTION
Adding pages to ghes sync script to prevent unknown addition to ghes and keep it up-to-date