### PR TITLE
Add setup-python to list of enabledActions for ghes

### DIFF
--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -18,6 +18,7 @@
     "actions/setup-go",
     "actions/setup-java",
     "actions/setup-node",
+    "actions/setup-python",
     "actions/stale",
     "actions/starter-workflows",
     "actions/upload-artifact",


### PR DESCRIPTION
`actions/setup-python` is part of ghes. So making it enabled in sync ghes script to allow actions using only that to be part of GHES