### PR TITLE
Starter Workflows Failing on Private Repositories - add actions: read permission when using upload-sarif

### DIFF
--- a/code-scanning/apisec-scan.yml
+++ b/code-scanning/apisec-scan.yml
@@ -49,6 +49,7 @@ jobs:
   Trigger APIsec scan:
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     steps:

--- a/code-scanning/brakeman.yml
+++ b/code-scanning/brakeman.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: Brakeman Scan
     runs-on: ubuntu-latest
     steps:

--- a/code-scanning/checkmarx.yml
+++ b/code-scanning/checkmarx.yml
@@ -29,6 +29,7 @@ jobs:
       issues: write # for checkmarx-ts/checkmarx-cxflow-github-action to write feedback to github issues
       pull-requests: write # for checkmarx-ts/checkmarx-cxflow-github-action to write feedback to PR
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     # Steps require - checkout code, run CxFlow Action, Upload SARIF report (optional)

--- a/code-scanning/clj-holmes.yml
+++ b/code-scanning/clj-holmes.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/code-scanning/clj-watson.yml
+++ b/code-scanning/clj-watson.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/code-scanning/codacy.yml
+++ b/code-scanning/codacy.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: Codacy Security Scan
     runs-on: ubuntu-latest
     steps:

--- a/code-scanning/codescan.yml
+++ b/code-scanning/codescan.yml
@@ -25,6 +25,7 @@ jobs:
         permissions:
           contents: read # for actions/checkout to fetch code
           security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+          actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout repository

--- a/code-scanning/contrast-scan.yml
+++ b/code-scanning/contrast-scan.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
         contents: read # for actions/checkout
         security-events: write # for github/codeql-action/upload-sarif
+        actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     # check out project
     steps:

--- a/code-scanning/eslint.yml
+++ b/code-scanning/eslint.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/code-scanning/hadolint.yml
+++ b/code-scanning/hadolint.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/code-scanning/lintr.yml
+++ b/code-scanning/lintr.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read # for checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
 
     steps:
       - name: Checkout code

--- a/code-scanning/mobsf.yml
+++ b/code-scanning/mobsf.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     steps:

--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: Analyze
     runs-on: windows-latest
 

--- a/code-scanning/njsscan.yml
+++ b/code-scanning/njsscan.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     name: njsscan code scanning
     steps:

--- a/code-scanning/ossar.yml
+++ b/code-scanning/ossar.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: windows-latest
 
     steps:

--- a/code-scanning/phpmd.yml
+++ b/code-scanning/phpmd.yml
@@ -34,6 +34,7 @@ jobs:
     permissions:
       contents: read # for checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
 
     steps:
       - name: Checkout code

--- a/code-scanning/pmd.yml
+++ b/code-scanning/pmd.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/code-scanning/powershell.yml
+++ b/code-scanning/powershell.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:

--- a/code-scanning/prisma.yml
+++ b/code-scanning/prisma.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     name: Run Prisma Cloud IaC Scan to check
     steps:

--- a/code-scanning/puppet-lint.yml
+++ b/code-scanning/puppet-lint.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read # for checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
 
     steps:
       - name: Checkout code

--- a/code-scanning/rust-clippy.yml
+++ b/code-scanning/rust-clippy.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/code-scanning/semgrep.yml
+++ b/code-scanning/semgrep.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: Scan
     runs-on: ubuntu-latest
     steps:

--- a/code-scanning/snyk-container.yml
+++ b/code-scanning/snyk-container.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/code-scanning/snyk-infrastructure.yml
+++ b/code-scanning/snyk-infrastructure.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/code-scanning/sobelow.yml
+++ b/code-scanning/sobelow.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     steps:

--- a/code-scanning/sysdig-scan.yml
+++ b/code-scanning/sysdig-scan.yml
@@ -24,6 +24,7 @@ jobs:
       checks: write # for sysdiglabs/scan-action to publish the checks
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     steps:

--- a/code-scanning/trivy.yml
+++ b/code-scanning/trivy.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     name: Build
     runs-on: "ubuntu-18.04"
     steps:

--- a/code-scanning/veracode.yml
+++ b/code-scanning/veracode.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
     steps:
 

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -51,6 +51,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This is a fix for any starter workflow that is using the `github/codeql-action/upload-sarif` action that is [overriding the default GITHUB_TOKEN permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) and NOT explicitly including `actions: read`.  

This is documented as a required permission in the [Example workflow for SARIF files generated outside of a repository](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository). 
   - workflows have already been fixed. (ex: https://github.com/actions/starter-workflows/pull/1589)

Currently, these actions will fail (with 403) for a private repository using github/codeql-action/upload-sarif to [get the Action run status ](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run).  Example:

> Error: codeql/upload-sarif action failed: HttpError: Resource not accessible by integration
> RequestError [HttpError]: Resource not accessible by integration
>     at /home/runner/work/_actions/github/codeql-action/v2/node_modules/@octokit/request/dist-node/index.js:66:23
>     at processTicksAndRejections (node:internal/process/task_queues:[9](https://github.com/ghas-bootcamp/ghas-bootcamp-felickz/actions/runs/3055907178/jobs/4929493151#step:5:10)6:5)
>     at async Job.doExecute (/home/runner/work/_actions/github/codeql-action/v2/node_modules/bottleneck/light.js:405:18) {
>   status: 403,
>   headers: {
>     'access-control-allow-origin': '*',
>     'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
>     connection: 'close',
>     'content-encoding': 'gzip',
>     'content-security-policy': "default-src 'none'",
>     'content-type': 'application/json; charset=utf-8',
>     date: 'Wed, 14 Sep 2022 20:33:17 GMT',
>     'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
>     server: 'GitHub.com',
>     'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
>     'transfer-encoding': 'chunked',
>     vary: 'Accept-Encoding, Accept, X-Requested-With',
>     'x-content-type-options': 'nosniff',
>     'x-frame-options': 'deny',
>     'x-github-media-type': 'github.v3; format=json',
>     'x-github-request-id': '0440:67EA:91FC90:[12](https://github.com/ghas-bootcamp/ghas-bootcamp-felickz/actions/runs/3055907178/jobs/4929493151#step:5:13)AA4AC:63223A8D',
>     'x-ratelimit-limit': '15000',
>     'x-ratelimit-remaining': '14921',
>     'x-ratelimit-reset': '1663189744',
>     'x-ratelimit-resource': 'core',
>     'x-ratelimit-used': '79',
>     'x-xss-protection': '0'
>   },
>   request: {
>     method: 'GET',
>     url: 'https://api.github.com/repos/ghas-bootcamp/ghas-bootcamp-felickz/actions/runs/3055874047?exclude_pull_requests=true',
>     headers: {
>       accept: 'application/vnd.github.v3+json',
>       'user-agent': 'CodeQL-Action/2.1.22 octokit-core.js/3.1.2 Node.js/16.[13](https://github.com/ghas-bootcamp/ghas-bootcamp-felickz/actions/runs/3055907178/jobs/4929493151#step:5:14).0 (linux; x64)',
>       authorization: 'token [REDACTED]'
>     },
>     request: { agent: [Agent], hook: [Function: bound bound register] }
>   },
>   documentation_url: 'https://docs.github.com/rest/reference/actions#get-a-workflow-run'
> }
> 



<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [ ] Should specify least priviledge [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _CI_ workflows, the workflow:**

- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [ ] `name`: Name of the Code Scanning integration.
  - [ ] `organization`: Name of the organization producing the Code Scanning integration.
  - [ ] `description`: Short description of the Code Scanning integration.
  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [ ] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Automation and CI workflows cannot be dependent on a paid service or product.
