### PR TITLE
Update CodeQL to include category by default

### DIFF
--- a/code-scanning/codeql.yml
+++ b/code-scanning/codeql.yml
@@ -70,3 +70,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Code Scanning can accept multiple uploads for the same tool and uses the concept of category to keep results separated. If not provided explicitly, the category is computed based on a few parameters like workflow path and matrix variables. The implicit computation of the category can create confusion if users change their workflow, as we start considering the new analyses as unrelated to existing results.

By making the category explicit in the workflow we hope to make the concept more prominent and reduce accidental changes.
https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#configuring-a-category-for-the-analysis

This is updating an existing workflow file.

