### PR TITLE
Hide ESLint on GHES

### DIFF
--- a/code-scanning/properties/eslint.properties.json
+++ b/code-scanning/properties/eslint.properties.json
@@ -2,6 +2,7 @@
     "name": "ESLint",
     "description": "A tool for identifying and reporting the problems found in ECMAScript/JavaScript code.",
     "iconName": "eslint",
+    "enterprise": false,
     "categories": [
         "Code Scanning",
         "JavaScript",


### PR DESCRIPTION
👋 Hi! I'm from the GitHub Code Scanning team.

We've noticed that ESLint is being incorrectly displayed on GHES.

This change should hide the workflow. 🙇 