### PR TITLE
Make enterprise opt-in instead of opt-out

### DIFF
--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -1,6 +1,7 @@
 {
     "name": "CodeQL Analysis",
     "creator": "GitHub",
+    "enterprise": true,
     "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python, and Ruby developers.",
     "iconName": "octicon mark-github",
     "categories": ["Code Scanning", "C", "C++", "C#", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -61,7 +61,7 @@ async function checkWorkflows(
 
         const enabled =
           !isPartnerWorkflow &&
-          workflowProperties.enterprise === true &&
+          (workflowProperties.enterprise === true || folder !== 'code-scanning') &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -61,7 +61,7 @@ async function checkWorkflows(
 
         const enabled =
           !isPartnerWorkflow &&
-          workflowProperties.enterprise !== false &&
+          workflowProperties.enterprise === true &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {


### PR DESCRIPTION
This should stop workflows appearing on GHES when they have not explicitly been vetted as suitable.