### PR TITLE
fix trigger for ghes sync

### DIFF
--- a/.github/workflows/sync-ghes.yaml
+++ b/.github/workflows/sync-ghes.yaml
@@ -2,7 +2,7 @@ name: Sync workflows for GHES
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I think this bug snuck in when [updating all the template workflows to use `$default_branch`](https://github.com/actions/starter-workflows/pull/1724).