### PR TITLE
Update denoland/setup-deno workflow

### DIFF
--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# This workflow will install Deno then run Deno lint and test.
+# This workflow will install Deno then run `deno lint` and `deno test`.
 # For more information see: https://github.com/denoland/setup-deno
 
 name: Deno
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Deno
         # uses: denoland/setup-deno@v1
-        uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366
+        uses: denoland/setup-deno@9db7f66e8e16b5699a514448ce994936c63f0d54
         with:
           deno-version: v1.x
 
@@ -39,4 +39,4 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno test -A --unstable
+        run: deno test -A


### PR DESCRIPTION
This updates the version of the denoland/setup-deno action used in ci/deno.yml starter workflow to a version that uses node16, to remove the warning about node12 workflows being deprecated.

The version updated to is the latest released version, v1.1.1: https://github.com/denoland/setup-deno/releases/tag/v1.1.1
