### PR TITLE
Using node 18 for Gatsby

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [x] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

Gatsby 5 uses Node 18, [see](https://www.gatsbyjs.com/blog/gatsby-5-upgrade-say-no-to-yolo/) so I think this repo should use Node 18 by default.
