### PR TITLE
Fix code-scanning filtering for relative paths

### DIFF
--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -61,7 +61,7 @@ async function checkWorkflows(
 
         const enabled =
           !isPartnerWorkflow &&
-          (workflowProperties.enterprise === true || folder !== 'code-scanning') &&
+          (workflowProperties.enterprise === true || basename(folder) !== 'code-scanning') &&
           (await checkWorkflow(workflowFilePath, enabledActions));
 
         const workflowDesc: WorkflowDesc = {


### PR DESCRIPTION
This fixes a bug in https://github.com/actions/starter-workflows/pull/1759 where it would not correctly filter out workflows in the code-scanning directory because it was being compared against a relative path.

Not sure how I originally managed to make the script work. 😞 

Looks like I need this PR to merge first https://github.com/actions/starter-workflows/pull/1844 with a linter fix.