### PR TITLE
Add Kotlin to CodeQL supported languages.

### DIFF
--- a/code-scanning/properties/codeql.properties.json
+++ b/code-scanning/properties/codeql.properties.json
@@ -2,7 +2,7 @@
     "name": "CodeQL Analysis",
     "creator": "GitHub",
     "enterprise": true,
-    "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python, and Ruby developers.",
+    "description": "Security analysis from GitHub for C, C++, C#, Go, Java, JavaScript, TypeScript, Python, Ruby and Kotlin developers.",
     "iconName": "octicon mark-github",
-    "categories": ["Code Scanning", "C", "C++", "C#", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby"]
+    "categories": ["Code Scanning", "C", "C++", "C#", "Go", "Java", "JavaScript", "TypeScript", "Python", "Ruby", "Kotlin"]
 }


### PR DESCRIPTION
This updates the list of supported languages for CodeQL to include Kotlin, as Kotlin for CodeQL [is now in public beta](https://github.blog/changelog/2022-11-28-codeql-code-scanning-launches-kotlin-analysis-support-beta/).