### PR TITLE
Update scorecard.yml with latest releases

### DIFF
--- a/code-scanning/scorecard.yml
+++ b/code-scanning/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@807578363a7869ca324a79039e6db9c843e0e100 # v2.1.27
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Update scorecard.yml with latest releases for ossf/scorecard-action & github/codeql-action/upload-sarif

Noticed these were out-of-date when I saw the below warning on a recent run ([ref](https://github.com/ChrisCarini/automatic-github-issue-navigation-configuration-jetbrains-plugin/actions/runs/4190143423/jobs/7263241173)):
<img width="1383" alt="Screenshot 2023-02-15 at 19 09 45" src="https://user-images.githubusercontent.com/6374067/219258952-876e1310-b819-4581-8939-b8819d6784ab.png">
