### PR TITLE
Update jekyll workflow to use ruby 3.1

### DIFF
--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
         with:
-          ruby-version: '3.0' # Not needed with a .ruby-version file
+          ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages


### PR DESCRIPTION
This PR updates Jekyll workflow to ruby 3.1 to address potential bundle installation issues for jekyll-sass-converter 3.x.

https://jekyllrb.com/news/2022/12/21/jekyll-sass-converter-3.0-released/

Jekyll Sass Converter 3.0 has a minimum rubygems/bundler version requirement which the default rubygems in ruby 3.0 does not meet. While we can use setup-ruby action to update rubygems, ruby >=3.1.3 have the rubygems version that meets the requirement out of box.