### PR TITLE
Trim whitespace on pages/mdbook.yml

### DIFF
--- a/pages/mdbook.yml
+++ b/pages/mdbook.yml
@@ -38,14 +38,14 @@ jobs:
       # Runs a single command using the runners shell
       - name: install mdbook
         run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh 
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v1
       - name: Build with mdbook
-        run: mdbook build 
+        run: mdbook build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
Trims whitespace on pages/mdbook.yml, which raises linter errors.