### PR TITLE
bump cosign-installer to use v2, remove use of deprecated env var

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343 #v3.0.3
+        uses: sigstore/cosign-installer@dd6b2e2b610a11fd73dd187a43d57cc1394e35f9 #v3.0.5
         with:
           cosign-release: 'v2.0.2'
 

--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -41,9 +41,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343 #v3.0.3
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.0.2'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
@@ -89,8 +89,6 @@ jobs:
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
increments the version of `cosign` to be used to the latest release, and removes the now-unneeded environment variable `COSIGN_EXPERIMENTAL`