### PR TITLE
Update Hugo version and switch to Dart Sass

### DIFF
--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -31,14 +31,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.108.0
+      HUGO_VERSION: 0.114.0
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The Sass team has deprecated Embedded Dart Sass in favor of Dart Sass, requiring Hugo v0.114.0 or later.
