### PR TITLE
Update dotnet-desktop.yml

### DIFF
--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -75,7 +75,7 @@ jobs:
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     # Execute all unit tests in the solution
     - name: Execute unit tests


### PR DESCRIPTION
Maintainer of `setup-msbuild` here.  User reported they were getting Actions deprecation messages and noted they started with this template.  Updating this to use the `v1` tag which gets the latest major/minor/patch and resolves this.
