### PR TITLE
Update Postgres to current stable for rubyonrails

### DIFF
--- a/ci/rubyonrails.yml
+++ b/ci/rubyonrails.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11-alpine
+        image: postgres:16-alpine
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
Postgres 11 is approaching end-of-life in November.

I have tested this version in this actions template and it boots successfully.
