### PR TITLE
Add Pelican GitHub Pages starter workflow

### DIFF
--- a/pages/pelican.yml
+++ b/pages/pelican.yml
@@ -1,0 +1,57 @@
+# Sample workflow for building and deploying a Pelican site to GitHub Pages
+name: Deploy Pelican site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Pelican
+        run: pip install pelican[markdown] typogrify
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Pelican
+        run: |
+          pelican \
+            --settings publishconf.py \
+            --extra-settings SITEURL='"${{ steps.pages.outputs.base_url }}"'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: output/
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Add a starter workflow for using the Python static site generator Pelican (https://getpelican.com/) to publish to GitHub Pages. I've followed the approach taken by other GitHub Pages starter workflows in this directory.
