### PR TITLE
Fixes link to node release page

### DIFF
--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION

Fixes a broken link to the Node.Js release page, mentioned in the Node.Js starter workflow.