### PR TITLE
Update blank.yml - bump `actions/checkout` to `v4`.

### DIFF
--- a/ci/blank.yml
+++ b/ci/blank.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Runs a single command using the runners shell
       - name: Run a one-line script


### PR DESCRIPTION
`actions/checkout@v3` throws a warning/error regarding deprecation of `Node.js` 

This change bumps the checkout action to `v4` which uses the updated version of Node.js. 

![image](https://github.com/actions/starter-workflows/assets/9710739/4d8b015b-58a5-451f-9ecd-7d1977d725f5)
