### PR TITLE
Update all Pages workflows to `actions/cache@v4` for `node20` compliance

### DIFF
--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -65,7 +65,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: gatsby
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -62,7 +62,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .next/cache

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -60,7 +60,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: nuxt
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             dist


### PR DESCRIPTION
Updating all Pages starter workflows to use `actions/cache@v4` to eliminate warning annotations about needing to avoid Node.js 16.x. ⬆️ 