### PR TITLE
Code Scanning shouldn't own `dependency-review.yml`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 * @actions/actions-workflow-development-reviewers
 
 /code-scanning/ @actions/advanced-security-code-scanning @actions/actions-workflow-development-reviewers @actions/advanced-security-dependency-graph
+/code-scanning/dependency-review.yml @actions/actions-workflow-development-reviewers @actions/advanced-security-dependency-graph
 /pages/ @actions/pages @actions/actions-workflow-development-reviewers


### PR DESCRIPTION
I'm hoping that a more specific `CODEOWNERS` rule will fix ownership so Code Scanning won't be pinged for review on PRs like https://github.com/actions/starter-workflows/pull/2297 in future.