### PR TITLE
Add the concept of a "read-only" synced folder

### DIFF
--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -165,7 +165,7 @@ async function checkWorkflow(
 
     // Bring back the read-only folders
     console.log("Restore read-only folders");
-    await settings.readOnlyFolders.forEach(async (folder) => {
+    settings.readOnlyFolders.forEach(async (folder) => {
       await exec("git", [
         "checkout",
         folder

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -160,11 +160,17 @@ async function checkWorkflow(
     // just bring the compatible ones over from the main branch. We let git figure out
     // whether it's a deletion, add, or modify and commit the new state.
     console.log("Remove all workflows");
-    await exec("rm", ["-fr", ...(settings.folders.filter(x => !settings.readOnlyFolders.includes(x)))]);
+    await exec("rm", ["-fr", ...settings.folders]);
     await exec("rm", ["-fr", "../../icons"]);
 
-    // Ignore compatible workflows in a read-only folder
-    result.compatibleWorkflows = result.compatibleWorkflows.filter(x => !settings.readOnlyFolders.includes(x.folder));
+    // Bring back the read-only folders
+    console.log("Restore read-only folders");
+    settings.readOnlyFolders.forEach(async (folder) => {
+      await exec("git", [
+        "checkout",
+        folder
+      ]);
+    });
 
     console.log("Sync changes from main for compatible workflows");
     await exec("git", [

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -165,14 +165,12 @@ async function checkWorkflow(
 
     // Bring back the read-only folders
     console.log("Restore read-only folders");
-    await settings.readOnlyFolders.forEach(async (folder) => {
+    for (let i = 0; i < settings.readOnlyFolders.length; i++) {
       await exec("git", [
         "checkout",
-        folder
+        settings.readOnlyFolders[i]
       ]);
-    });
-
-    throw 'x'
+    }
 
     console.log("Sync changes from main for compatible workflows");
     await exec("git", [

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -163,6 +163,9 @@ async function checkWorkflow(
     await exec("rm", ["-fr", ...settings.folders]);
     await exec("rm", ["-fr", "../../icons"]);
 
+    // Ignore read-only folders from compatible workflows list
+    result.compatibleWorkflows = result.compatibleWorkflows.filter(x => !settings.readOnlyFolders.includes(x.folder));
+
     console.log("Sync changes from main for compatible workflows");
     await exec("git", [
       "checkout",
@@ -184,6 +187,9 @@ async function checkWorkflow(
         })
       ),
     ]);
+
+    // Add back Pages icons
+
   } catch (e) {
     console.error("Unhandled error while syncing workflows", e);
     process.exitCode = 1;

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -180,10 +180,13 @@ async function checkWorkflow(
       ...Array.prototype.concat.apply(
         [],
         result.compatibleWorkflows.map((x) => {
-          const r = [
-            join(x.folder, `${x.id}.yml`),
-            join(x.folder, "properties", `${x.id}.properties.json`),
-          ];
+          const r = [];
+
+          // Don't touch read-only folders
+          if (!settings.readOnlyFolders.includes(x.folder)) {
+            r.push(join(x.folder, `${x.id}.yml`));
+            r.push(join(x.folder, "properties", `${x.id}.properties.json`));
+          };
 
           if (x.iconType === "svg") {
             r.push(join("../../icons", `${x.iconName}.svg`));

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -156,11 +156,11 @@ async function checkWorkflow(
     await exec("git", ["checkout", "ghes"]);
 
     // In order to sync from main, we might need to remove some workflows, add some
-    // and modify others. The lazy approach is to delete all workflows first, and then
+    // and modify others. The lazy approach is to delete all workflows first (except from read-only folders), and then
     // just bring the compatible ones over from the main branch. We let git figure out
     // whether it's a deletion, add, or modify and commit the new state.
     console.log("Remove all workflows");
-    await exec("rm", ["-fr", ...settings.folders]);
+    await exec("rm", ["-fr", ...(settings.folders.filter(x => !settings.readOnlyFolders.includes(x)))]);
     await exec("rm", ["-fr", "../../icons"]);
 
     // Ignore compatible workflows in a read-only folder

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -196,9 +196,6 @@ async function checkWorkflow(
         })
       ),
     ]);
-
-    // Add back Pages icons
-
   } catch (e) {
     console.error("Unhandled error while syncing workflows", e);
     process.exitCode = 1;

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -153,7 +153,7 @@ async function checkWorkflow(
     console.groupEnd();
 
     console.log("Switch to GHES branch");
-    // await exec("git", ["checkout", "ghes"]);
+    await exec("git", ["checkout", "ghes"]);
 
     // In order to sync from main, we might need to remove some workflows, add some
     // and modify others. The lazy approach is to delete all workflows first, and then

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -172,6 +172,8 @@ async function checkWorkflow(
       ]);
     });
 
+    throw 'x'
+
     console.log("Sync changes from main for compatible workflows");
     await exec("git", [
       "checkout",

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -165,7 +165,7 @@ async function checkWorkflow(
 
     // Bring back the read-only folders
     console.log("Restore read-only folders");
-    settings.readOnlyFolders.forEach(async (folder) => {
+    await settings.readOnlyFolders.forEach(async (folder) => {
       await exec("git", [
         "checkout",
         folder

--- a/script/sync-ghes/index.ts
+++ b/script/sync-ghes/index.ts
@@ -153,7 +153,7 @@ async function checkWorkflow(
     console.groupEnd();
 
     console.log("Switch to GHES branch");
-    await exec("git", ["checkout", "ghes"]);
+    // await exec("git", ["checkout", "ghes"]);
 
     // In order to sync from main, we might need to remove some workflows, add some
     // and modify others. The lazy approach is to delete all workflows first, and then
@@ -163,7 +163,7 @@ async function checkWorkflow(
     await exec("rm", ["-fr", ...settings.folders]);
     await exec("rm", ["-fr", "../../icons"]);
 
-    // Ignore read-only folders from compatible workflows list
+    // Ignore compatible workflows in a read-only folder
     result.compatibleWorkflows = result.compatibleWorkflows.filter(x => !settings.readOnlyFolders.includes(x.folder));
 
     console.log("Sync changes from main for compatible workflows");

--- a/script/sync-ghes/settings.json
+++ b/script/sync-ghes/settings.json
@@ -2,7 +2,11 @@
   "folders": [
     "../../ci",
     "../../automation",
-    "../../code-scanning"
+    "../../code-scanning",
+    "../../pages"
+  ],
+  "readOnlyFolders": [
+    "../../pages"
   ],
   "enabledActions": [
     "actions/cache",


### PR DESCRIPTION
A read-only synced folder is a folder that:

- Has workflows shipped to GHES
- BUT should not be touched by the sync process

Icons associated with a read-only folder should still stay on the `ghes` branch.

**More context:**  

In PRs:

- https://github.com/actions/starter-workflows/pull/2366
- https://github.com/actions/starter-workflows/pull/2376
- https://github.com/actions/starter-workflows/pull/2387

In English:

> Pages' starter workflows on the `main` branch are not compatible with GHES anymore until artifacts v4 makes it there. We have attempted various way to work around the GHES sync in this repo (what keep in sync the starter workflow between the `main` and `ghes` branch for GHES). The current state is "ok-ish", as in, [our icons have disappeared](https://github.com/actions/starter-workflows/commit/5c5d982a32993ae6c708307a42cd90a98f6d5cc4) but at least our workflows are there. This PR fixes that with a better solution. It's still a bit hard to wrap once's head around the whole thing, but it does what it should.

## Pre-requisites

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [ ] Should specify least privileged [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _CI_ workflows, the workflow:**

- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [ ] `name`: Name of the Code Scanning integration.
  - [ ] `creator`: Name of the organization/user producing the Code Scanning integration.
  - [ ] `description`: Short description of the Code Scanning integration.
  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [ ] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Automation and CI workflows cannot be dependent on a paid service or product.
