### PR TITLE
go: update to use go1.22

### DIFF
--- a/ci/go.yml
+++ b/ci/go.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: '1.22'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
go 1.20 is EOL, update to use 1.22

also update setup-go to use nodejs 20 runtime dep