### PR TITLE
CodeQL: Add `actions: write` permission to support TRAP cache cleanup

### DIFF
--- a/code-scanning/codeql.yml
+++ b/code-scanning/codeql.yml
@@ -77,7 +77,8 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
       shell: bash
       run: |
         echo 'If you are using a "manual" build mode for one or more of the' \

--- a/code-scanning/codeql.yml
+++ b/code-scanning/codeql.yml
@@ -33,11 +33,13 @@ jobs:
       # required for all workflows
       security-events: write
 
+      # required to clean up CodeQL TRAP caches
+      actions: write
+
       # required to fetch internal or private CodeQL packs
       packages: read
 
       # only required for workflows in private repositories
-      actions: read
       contents: read
 
     strategy:


### PR DESCRIPTION
This PR adds the `actions: write` permission to the CodeQL workflow so that the CodeQL workflow can automatically cleanup unused CodeQL TRAP caches.

While we're here, we also add a step name for the manual build commands step, so it's more clear what is going on when this step is skipped.