### PR TITLE
Update cosign versions in Docker-publish

### DIFF
--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -41,9 +41,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: 'v2.2.4'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache


### PR DESCRIPTION
The existing docker-publish workflow has stopped working due to issues with the signing implementation. I noticed this in my personal workflow [here]( https://github.com/jhutchings1/transcode-dvr-recordings/actions/runs/9305924653). It was resolved by updating cosign-installer, and the version of cosign used [here](https://github.com/jhutchings1/transcode-dvr-recordings/actions/runs/9306007317). 