### PR TITLE
Update DataDog/synthetics-ci-github-action workflow

### DIFF
--- a/ci/datadog-synthetics.yml
+++ b/ci/datadog-synthetics.yml
@@ -29,7 +29,7 @@ jobs:
     # Run Synthetic tests within your GitHub workflow.
     # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
     - name: Run Datadog Synthetic tests
-      uses: DataDog/synthetics-ci-github-action@2b56dc0cca9daa14ab69c0d1d6844296de8f941e
+      uses: DataDog/synthetics-ci-github-action@c36b031081c29b54513d7faba468ddd5b248baf3 # v1.4.0
       with:
         api_key: ${{secrets.DD_API_KEY}}
         app_key: ${{secrets.DD_APP_KEY}}

--- a/ci/datadog-synthetics.yml
+++ b/ci/datadog-synthetics.yml
@@ -29,7 +29,7 @@ jobs:
     # Run Synthetic tests within your GitHub workflow.
     # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
     - name: Run Datadog Synthetic tests
-      uses: DataDog/synthetics-ci-github-action@c36b031081c29b54513d7faba468ddd5b248baf3 # v1.4.0
+      uses: DataDog/synthetics-ci-github-action@87b505388a22005bb8013481e3f73a367b9a53eb # v1.4.0
       with:
         api_key: ${{secrets.DD_API_KEY}}
         app_key: ${{secrets.DD_APP_KEY}}


### PR DESCRIPTION
This PR updates the Datadog/synthetics-ci-github-action workflow version to v1.4.0.
The release can be found here: https://github.com/DataDog/synthetics-ci-github-action/releases/tag/v1.4.0
