### PR TITLE
Update stale.yml to only use workflow_dispatch

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,9 @@
 name: Mark stale issues and pull requests
 
 on:
-  schedule:
-  - cron: "21 4 * * *"
+  workflow_dispatch:
+  # schedule:
+  # - cron: "21 4 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
Having old PRs be closed when no one is looking at them isn't a good experience. I'm changing the stale workflow to be `workflow_dispatch` only so PRs aren't auto-closed