### PR TITLE
Update bandit.yml with version bump

### DIFF
--- a/code-scanning/bandit.yml
+++ b/code-scanning/bandit.yml
@@ -7,7 +7,7 @@
 # This action will run Bandit on your codebase.
 # The results of the scan will be found under the Security tab of your repository.
 
-# https://github.com/marketplace/actions/bandit-scan is ISC licensed, by abirismyname
+# https://github.com/marketplace/actions/python-bandit-scan is ISC licensed, by abirismyname and maintained by reactive-firewall
 # https://pypi.org/project/bandit/ is Apache v2.0 licensed, by PyCQA
 
 name: Bandit
@@ -20,29 +20,31 @@ on:
   schedule:
     - cron: $cron-weekly
 
+permissions: {}  # Default global permissions to none.
+
 jobs:
   bandit:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-
+    
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: shundor/python-bandit-scan@9cc5aa4a006482b8a7f91134412df6772dbda22c
+        uses: reactive-firewall/python-bandit-scan@v2.1  # v2.1 - c8b1d56a3964de4e00e7a820dddb38661a4b7566
         with: # optional arguments
-          # exit with 0, even with results found
+          # exit with 0, even with results found - remove or set to false to fail on results when found.
           exit_zero: true # optional, default is DEFAULT
           # Github token of the repository (automatically created by Github)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
           # File or directory to run bandit on
-          # path: # optional, default is .
+          # path: "." # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # level: # optional, default is UNDEFINED
+          # level: high # optional, default is UNDEFINED
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # confidence: # optional, default is UNDEFINED
+          # confidence: high # optional, default is UNDEFINED
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
           # excluded_paths: # optional, default is DEFAULT
           # comma-separated list of test IDs to skip

--- a/code-scanning/bandit.yml
+++ b/code-scanning/bandit.yml
@@ -28,12 +28,11 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: reactive-firewall/python-bandit-scan@v2.1  # v2.1 - c8b1d56a3964de4e00e7a820dddb38661a4b7566
+        uses: reactive-firewall/python-bandit-scan@ c8b1d56a3964de4e00e7a820dddb38661a4b7566  # v2.1 - c8b1d56a3964de4e00e7a820dddb38661a4b7566
         with: # optional arguments
           # exit with 0, even with results found - remove or set to false to fail on results when found.
           exit_zero: true # optional, default is DEFAULT

--- a/code-scanning/bandit.yml
+++ b/code-scanning/bandit.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: reactive-firewall/python-bandit-scan@ c8b1d56a3964de4e00e7a820dddb38661a4b7566  # v2.1 - c8b1d56a3964de4e00e7a820dddb38661a4b7566
+        uses: reactive-firewall/python-bandit-scan@c8b1d56a3964de4e00e7a820dddb38661a4b7566  # v2.1 - c8b1d56a3964de4e00e7a820dddb38661a4b7566
         with: # optional arguments
           # exit with 0, even with results found - remove or set to false to fail on results when found.
           exit_zero: true # optional, default is DEFAULT


### PR DESCRIPTION
## Migrate to latest, maintained, version of bandit code-scanning action.

### Noteworthy changes:
 * Maintained action is a fork of the unmaintained previous version. - Versions are still pinnable ( including bug-for-bug compatible `v1.0` ) - Maintained project now utilizes @dependabot to keep sub-dependencies current.
 * Maintained action is already released on marketplace.
 * Credits updated with both original and maintainer with no change to licensing.
 * Updated to use checkout@v4 now.

---

<details>
<summary>📋 TL;DR - PR Template with checklist from code owners</summary>

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [x] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [x] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [x] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [x] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] Should specify least privileged [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _Code Scanning_ workflows, the workflow:**

- [x] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [x] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [x] `name`: Name of the Code Scanning integration.
  - [ ] `creator`: Name of the organization/user producing the Code Scanning integration.
  **PLEASE ADVISE** [does this need to be changed?](https://github.com/reactive-firewall/starter-workflows/blob/main/code-scanning/properties/bandit.properties.json#L3)
  - [x] `description`: Short description of the Code Scanning integration.
  - [x] `categories`: Array of languages supported by the Code Scanning integration.
  - [x] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [x] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [x] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.

</details>