### PR TITLE
jekyll: append the forward slash at the end of base url path

### DIFF
--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}/"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
When moving from gh-pages based deployment to Github actions based deployment, I came across the problem where the asset paths (eg: css, images, js) was not generating properly.

After a bit of inspection, the base path for the url was expected to have a `/` which is missing in the default workflow.

After adding this change to my workflow, the site rendered correctly.