### PR TITLE
Fix pre-commit deprecated stage names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     files: (automation/|ci/|code-scanning/|deployments/|pages/).*(yaml|yml|json)$


### PR DESCRIPTION
> Run pre-commit run --all-files --show-diff-on-failure --color always
> [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
> [WARNING] repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
> [INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.

- https://github.com/pre-commit/pre-commit-hooks/pull/1093

## Pre-requisites

## Tasks
