### PR TITLE
Update starter workflows to use the latest artifact actions

### DIFF
--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -109,7 +109,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MSIX Package
         path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Upload SARIF file as an Artifact to download and view
       # - name: Upload SARIF as an Artifact
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: sarif-file
       #     path: ${{ steps.run-analysis.outputs.sarif }}

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -87,7 +87,7 @@ jobs:
           license: ${{ secrets.XANITIZER_LICENSE }}
 
       # Archiving the findings list reports
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Xanitizer-Reports
           path: |

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -59,7 +59,7 @@ jobs:
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: .net-app
           path: ${{env.DOTNET_ROOT}}/myapp
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: .net-app
 

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -50,7 +50,7 @@ jobs:
         run: gradle build
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-app
           path: '${{ github.workspace }}/build/libs/*.jar'
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -50,7 +50,7 @@ jobs:
         run: mvn clean install
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-app
           path: '${{ github.workspace }}/target/*.jar'
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java-app
 

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -49,7 +49,7 @@ jobs:
         npm run test --if-present
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: node-app
         path: .
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: node-app
 

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -70,7 +70,7 @@ jobs:
         run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: php-app
           path: .
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: php-app
 

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -55,7 +55,7 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
 
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-app
           path: .


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


The v3 artifact actions are being deprecated, we should use v4 instead.

Note:
1. I have not tested each workflow individually, but the usage seems relatively straightforward so I do not think any of the breaking changes should affect this workflows
2. The v4 artifact actions are not supported on GHES - https://github.com/actions/starter-workflows/pull/2726/commits/72cd01c7a5c81442cf791b989bdb6d67deaded76 should ensure the GHES version of these workflows remains v3

- #2383
- #2458