### PR TITLE
Add --locked to Rust cargo actions

### DIFF
--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --locked
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --locked


### PR DESCRIPTION
This causes dependencies to be resolved in exactly the same way as they were in the Cargo.lock file, leading to more deterministic builds. Committing Cargo.lock and using this flag in CI is considered best practice, as suggested by the cargo book.

https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options