### PR TITLE
Add minimal permissions to dotnet workflow for improved security

### DIFF
--- a/ci/dotnet.yml
+++ b/ci/dotnet.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ $default-branch ]
 
+# Set minimal required permissions for the workflow.
+# This follows the principle of least privilege and improves security.
+permissions:
+  contents: read
+  
 jobs:
   build:
 


### PR DESCRIPTION
This PR updates the Dotnet workflow to include `permissions: contents: read`, ensuring the workflow follows the principle of least privilege and improves security.

**Key changes:**
- Added `permissions: contents: read` to the workflow file.

No functional changes to the build or test steps.

---

### Checklist

- [x] Workflow file is in the correct directory and uses lower-kebab-case.
- [x] Workflow name is "dotnet".
- [x] Step names use sentence case.
- [x] Workflow uses `$default-branch` for triggers (if applicable).
- [x] Includes `permissions: contents: read`.
- [x] Only official GitHub or ecosystem actions used.
- [x] Comments are present and clear.
