### PR TITLE
Remove redundant $ symbol in google-cloudrun-docker.yml

### DIFF
--- a/deployments/google-cloudrun-docker.yml
+++ b/deployments/google-cloudrun-docker.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: 'Build and Push Container'
         run: |-
-          DOCKER_TAG="$${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}"
+          DOCKER_TAG="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}"
           docker build --tag "${DOCKER_TAG}" .
           docker push "${DOCKER_TAG}"
       - name: 'Deploy to Cloud Run'


### PR DESCRIPTION
Fix a bug in `google-cloudrun-docker.yml`. 

When defining the `DOCKER_TAG` variable, an extra dollar sign ($) was incorrectly prepended to the `${{ env.REGION }}` expression. This caused the shell to misinterpret the variable during expansion. 

Specifically, when `env.REGION` was set to `us-central1-c`, the shell attempted to expand `$us-central1-c`. Because the variable `$us` was undefined, it was replaced with an empty string, resulting in a malformed image tag that started with `-central1-c`.cThis tag format is invalid according to Docker's naming conventions, which caused the build step to fail.