### PR TITLE
Fix build error in google-cloudrun-docker.yml by adding repo id, reformat the codes

### DIFF
--- a/deployments/google-cloudrun-docker.yml
+++ b/deployments/google-cloudrun-docker.yml
@@ -38,6 +38,7 @@ env:
   PROJECT_ID: 'my-project' # TODO: update to your Google Cloud project ID
   REGION: 'us-central1' # TODO: update to your region
   SERVICE: 'my-service' # TODO: update to your service name
+  REPOSITORY: 'my-repository' # TODO: update to your Artifact Registry repo name
   WORKLOAD_IDENTITY_PROVIDER: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
 
 jobs:
@@ -74,13 +75,13 @@ jobs:
 
       - name: 'Build and Push Container'
         run: |-
-          DOCKER_TAG="$${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}"
+          DOCKER_TAG="$${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}"
           docker build --tag "${DOCKER_TAG}" .
           docker push "${DOCKER_TAG}"
+      #
+      # END - Docker auth and build
+      
       - name: 'Deploy to Cloud Run'
-
-        # END - Docker auth and build
-
         uses: 'google-github-actions/deploy-cloudrun@33553064113a37d688aa6937bacbdc481580be17' # google-github-actions/deploy-cloudrun@v2
         with:
           service: '${{ env.SERVICE }}'


### PR DESCRIPTION
Original codes will result in an error `Pushes should be of the form docker push HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE`. The correct format for the path is `<region>-docker.pkg.dev/<project-id>/<repository-name>/<image-name>:<tag>`. The previous version forgot to add `<repository-name>`. Update to fix this bug. 

Also change the comments to the correct location.