### PR TITLE
New tool to detect outdated versions // and update GitHub managed ones

### DIFF
--- a/automation/greetings.yml
+++ b/automation/greetings.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Message that will be displayed on users' first issue"

--- a/automation/label.yml
+++ b/automation/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/automation/stale.yml
+++ b/automation/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/automation/summary.yml
+++ b/automation/summary.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run AI inference
         id: inference
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@v2
         with:
           prompt: |
             Summarize the following GitHub issue in one paragraph:

--- a/automation/summary.yml
+++ b/automation/summary.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run AI inference
         id: inference

--- a/ci/ada.yml
+++ b/ci/ada.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up GNAT toolchain
       run: >

--- a/ci/android.yml
+++ b/ci/android.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: set up JDK 11
       uses: actions/setup-java@v4
       with:

--- a/ci/android.yml
+++ b/ci/android.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/ci/ant.yml
+++ b/ci/ant.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:

--- a/ci/ant.yml
+++ b/ci/ant.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/ci/blank.yml
+++ b/ci/blank.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Runs a single command using the runners shell
       - name: Run a one-line script

--- a/ci/c-cpp.yml
+++ b/ci/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: configure
       run: ./configure
     - name: make

--- a/ci/clojure.yml
+++ b/ci/clojure.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: lein deps
     - name: Run tests

--- a/ci/cmake-multi-platform.yml
+++ b/ci/cmake-multi-platform.yml
@@ -45,7 +45,7 @@ jobs:
             c_compiler: cl
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/ci/cmake-single-platform.yml
+++ b/ci/cmake-single-platform.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/ci/crystal.yml
+++ b/ci/crystal.yml
@@ -15,7 +15,7 @@ jobs:
       image: crystallang/crystal
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: shards install
     - name: Run tests

--- a/ci/d.yml
+++ b/ci/d.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
 
     - name: 'Build & Test'

--- a/ci/dart.yml
+++ b/ci/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:

--- a/ci/datadog-synthetics.yml
+++ b/ci/datadog-synthetics.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Run Synthetic tests within your GitHub workflow.
     # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci

--- a/ci/deno.yml
+++ b/ci/deno.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         # uses: denoland/setup-deno@v1

--- a/ci/django.yml
+++ b/ci/django.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/ci/django.yml
+++ b/ci/django.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/ci/docker-image.yml
+++ b/ci/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
 

--- a/ci/dotnet-desktop.yml
+++ b/ci/dotnet-desktop.yml
@@ -109,7 +109,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: MSIX Package
         path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/ci/dotnet.yml
+++ b/ci/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/ci/dotnet.yml
+++ b/ci/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -28,7 +28,7 @@ jobs:
         elixir-version: '1.15.2' # [Required] Define the Elixir version
         otp-version: '26.0'      # [Required] Define the Erlang/OTP version
     - name: Restore dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -28,7 +28,7 @@ jobs:
         elixir-version: '1.15.2' # [Required] Define the Elixir version
         otp-version: '26.0'      # [Required] Define the Erlang/OTP version
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/ci/elixir.yml
+++ b/ci/elixir.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Elixir
       uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
       with:

--- a/ci/erlang.yml
+++ b/ci/erlang.yml
@@ -19,7 +19,7 @@ jobs:
       image: erlang:22.0.7
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Compile
       run: rebar3 compile
     - name: Run tests

--- a/ci/gem-push.yml
+++ b/ci/gem-push.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby 2.6
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/ci/generator-generic-ossf-slsa3-publish.yml
+++ b/ci/generator-generic-ossf-slsa3-publish.yml
@@ -23,7 +23,7 @@ jobs:
       digests: ${{ steps.hash.outputs.digests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ========================================================
       #

--- a/ci/go.yml
+++ b/ci/go.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/ci/go.yml
+++ b/ci/go.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.20'
 

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/ci/gradle-publish.yml
+++ b/ci/gradle-publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/ci/gradle.yml
+++ b/ci/gradle.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -54,7 +54,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -22,7 +22,7 @@ jobs:
         cabal-version: '3.2'
 
     - name: Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-cabal
       with:

--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -22,7 +22,7 @@ jobs:
         cabal-version: '3.2'
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-cabal
       with:

--- a/ci/haskell.yml
+++ b/ci/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-haskell@v1
       with:
         ghc-version: '8.10.3'

--- a/ci/ios.yml
+++ b/ci/ios.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/ci/jekyll-docker.yml
+++ b/ci/jekyll-docker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build the site in the jekyll/builder container
       run: |
         docker run \

--- a/ci/laravel.yml
+++ b/ci/laravel.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
         php-version: '8.0'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies

--- a/ci/makefile.yml
+++ b/ci/makefile.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: configure
       run: ./configure

--- a/ci/maven-publish.yml
+++ b/ci/maven-publish.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:

--- a/ci/maven-publish.yml
+++ b/ci/maven-publish.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/ci/maven.yml
+++ b/ci/maven.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/ci/msbuild.yml
+++ b/ci/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -20,7 +20,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/ci/node.js.yml
+++ b/ci/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/ci/npm-publish-github-packages.yml
+++ b/ci/npm-publish-github-packages.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -25,7 +25,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/ci/npm-publish-github-packages.yml
+++ b/ci/npm-publish-github-packages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: npm ci
@@ -26,7 +26,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: $registry-url(npm)

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -22,7 +22,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/ci/npm-publish.yml
+++ b/ci/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: npm ci
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/ci/objective-c-xcode.yml
+++ b/ci/objective-c-xcode.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/ci/php.yml
+++ b/ci/php.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/ci/pylint.yml
+++ b/ci/pylint.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/ci/pylint.yml
+++ b/ci/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/ci/python-app.yml
+++ b/ci/python-app.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/ci/python-package-conda.yml
+++ b/ci/python-package-conda.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/ci/python-package-conda.yml
+++ b/ci/python-package-conda.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Add conda to system path

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/ci/python-package.yml
+++ b/ci/python-package.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -33,7 +33,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-dists
           path: dist/

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/ci/python-publish.yml
+++ b/ci/python-publish.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: release-dists
           path: dist/

--- a/ci/r.yml
+++ b/ci/r.yml
@@ -25,7 +25,7 @@ jobs:
         r-version: ['3.6.3', '4.1.1']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up R ${{ matrix.r-version }}
         uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a
         with:

--- a/ci/ruby.yml
+++ b/ci/ruby.yml
@@ -25,7 +25,7 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/ci/rubyonrails.yml
+++ b/ci/rubyonrails.yml
@@ -27,7 +27,7 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # Add or replace dependency steps here
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
         with:

--- a/ci/rust.yml
+++ b/ci/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/ci/scala.yml
+++ b/ci/scala.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:

--- a/ci/scala.yml
+++ b/ci/scala.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/ci/super-linter.yml
+++ b/ci/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/ci/swift.yml
+++ b/ci/swift.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/ci/symfony.yml
+++ b/ci/symfony.yml
@@ -29,7 +29,7 @@ jobs:
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/ci/symfony.yml
+++ b/ci/symfony.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: shivammathur/setup-php@2cb9b829437ee246e9b3cac53555a39208ca6d28
       with:
         php-version: '8.0'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Copy .env.test.local
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
     - name: Cache Composer packages

--- a/ci/symfony.yml
+++ b/ci/symfony.yml
@@ -29,7 +29,7 @@ jobs:
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/ci/webpack.yml
+++ b/ci/webpack.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/ci/webpack.yml
+++ b/ci/webpack.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4

--- a/code-scanning/anchore-syft.yml
+++ b/code-scanning/anchore-syft.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
     - name: Scan the image and upload dependency results

--- a/code-scanning/anchore.yml
+++ b/code-scanning/anchore.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
     - name: Run the Anchore Grype scan action

--- a/code-scanning/appknox.yml
+++ b/code-scanning/appknox.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/code-scanning/bandit.yml
+++ b/code-scanning/bandit.yml
@@ -29,7 +29,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional arguments

--- a/code-scanning/bearer.yml
+++ b/code-scanning/bearer.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Scan code using Bearer CLI
       - name: Run Report
         id: report

--- a/code-scanning/black-duck-security-scan-ci.yml
+++ b/code-scanning/black-duck-security-scan-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Black Duck SCA scan
         uses: blackduck-inc/black-duck-security-scan@805cbd09e806b01907bbea0f990723c2bb85abe9
         with:

--- a/code-scanning/brakeman.yml
+++ b/code-scanning/brakeman.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Customize the ruby version depending on your needs
     - name: Setup Ruby

--- a/code-scanning/checkmarx-one.yml
+++ b/code-scanning/checkmarx-one.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # This step checks out a copy of your repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # This step creates the Checkmarx One scan
       - name: Checkmarx One scan
         uses: checkmarx/ast-github-action@8e887bb93dacc44e0f5b64ee2b06d5815f89d4fc

--- a/code-scanning/checkmarx.yml
+++ b/code-scanning/checkmarx.yml
@@ -35,7 +35,7 @@ jobs:
     # Steps require - checkout code, run CxFlow Action, Upload SARIF report (optional)
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # Runs the Checkmarx Scan leveraging the latest version of CxFlow - REFER to Action README for list of inputs
     - name: Checkmarx CxFlow Action
       uses: checkmarx-ts/checkmarx-cxflow-github-action@49d8269b14ca87910ba003d47a31fa0c7a11f2fe

--- a/code-scanning/clj-holmes.yml
+++ b/code-scanning/clj-holmes.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Scan code
         uses: clj-holmes/clj-holmes-action@200d2d03900917d7eb3c24fc691ab83579a87fcb

--- a/code-scanning/clj-watson.yml
+++ b/code-scanning/clj-watson.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency scan
         uses: clj-holmes/clj-watson-action@39b8ed306f2c125860cf6e69b6939363689f998c

--- a/code-scanning/cloudrail.yml
+++ b/code-scanning/cloudrail.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # For Terraform, Cloudrail requires the plan as input. So we generate it using
       # the Terraform core binary.

--- a/code-scanning/codacy.yml
+++ b/code-scanning/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/code-scanning/codeql.yml
+++ b/code-scanning/codeql.yml
@@ -53,7 +53,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/code-scanning/codescan.yml
+++ b/code-scanning/codescan.yml
@@ -31,7 +31,7 @@ jobs:
             -   name: Checkout repository
                 uses: actions/checkout@v4
             -   name: Cache files
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: |
                         ~/.sonar

--- a/code-scanning/codescan.yml
+++ b/code-scanning/codescan.yml
@@ -31,7 +31,7 @@ jobs:
             -   name: Checkout repository
                 uses: actions/checkout@v6
             -   name: Cache files
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: |
                         ~/.sonar

--- a/code-scanning/codescan.yml
+++ b/code-scanning/codescan.yml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -   name: Cache files
                 uses: actions/cache@v4
                 with:

--- a/code-scanning/contrast-scan.yml
+++ b/code-scanning/contrast-scan.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     # check out project
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # Since Contrast Scan is designed to run against your deployable artifact, the steps to build your artifact should go here.
     # -name: Build Project
     # ...

--- a/code-scanning/crda.yml
+++ b/code-scanning/crda.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # *******************************************************************
       # Required: Instructions to setup project

--- a/code-scanning/crda.yml
+++ b/code-scanning/crda.yml
@@ -94,7 +94,7 @@ jobs:
       #
       # Example:
       # - name: Setup Node
-      #   uses: actions/setup-node@v4
+      #   uses: actions/setup-node@v6
       #   with:
       #     node-version: '20'
 

--- a/code-scanning/credo.yml
+++ b/code-scanning/credo.yml
@@ -41,7 +41,7 @@ jobs:
         otp: [version]
         elixir: [version]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
         with:
           otp-version: ${{matrix.otp}}

--- a/code-scanning/crunch42.yml
+++ b/code-scanning/crunch42.yml
@@ -42,7 +42,7 @@ jobs:
       security-events: write # for 42Crunch/api-security-audit-action to upload results to Github Code Scanning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: 42Crunch REST API Static Security Testing
         uses: 42Crunch/api-security-audit-action@fc01ea7a89e6268875868f9d89598af7a9899ae0

--- a/code-scanning/datree.yml
+++ b/code-scanning/datree.yml
@@ -27,7 +27,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Datree policy check
         continue-on-error: true
         uses: datreeio/action-datree@de67ae7a5133d719dc794e1b75682cd4c5f94d8a

--- a/code-scanning/debricked.yml
+++ b/code-scanning/debricked.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: debricked/actions@v4
         env:
           DEBRICKED_TOKEN: ${{ secrets.DEBRICKED_TOKEN }}

--- a/code-scanning/defender-for-devops.yml
+++ b/code-scanning/defender-for-devops.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |

--- a/code-scanning/defender-for-devops.yml
+++ b/code-scanning/defender-for-devops.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           5.0.x

--- a/code-scanning/dependency-review.yml
+++ b/code-scanning/dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.

--- a/code-scanning/detekt.yml
+++ b/code-scanning/detekt.yml
@@ -45,7 +45,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Gets the download URL associated with the $DETEKT_RELEASE_TAG
     - name: Get Detekt download URL

--- a/code-scanning/devskim.yml
+++ b/code-scanning/devskim.yml
@@ -23,7 +23,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1

--- a/code-scanning/endorlabs.yml
+++ b/code-scanning/endorlabs.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     #### Package Build Instructions
     ### Use this section to define the build steps used by your software package.
     ### Endor Labs builds your software for you where possible but the required build tools must be made available.

--- a/code-scanning/endorlabs.yml
+++ b/code-scanning/endorlabs.yml
@@ -26,7 +26,7 @@ jobs:
     ### Use this section to define the build steps used by your software package.
     ### Endor Labs builds your software for you where possible but the required build tools must be made available.
     # - name: Setup Java
-    #   uses: actions/setup-java@v4
+    #   uses: actions/setup-java@v5
     #   with:
     #     distribution: 'microsoft'
     #     java-version: '17'

--- a/code-scanning/eslint.yml
+++ b/code-scanning/eslint.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install ESLint
         run: |

--- a/code-scanning/flawfinder.yml
+++ b/code-scanning/flawfinder.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: flawfinder_scan
         uses: david-a-wheeler/flawfinder@8e4a779ad59dbfaee5da586aa9210853b701959c

--- a/code-scanning/fortify.yml
+++ b/code-scanning/fortify.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Check out source code
       - name: Check Out Source Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Perform SAST and/or SCA scan via Fortify on Demand/Fortify Hosted/ScanCentral SAST/Debricked. Based on
       # configuration, the Fortify GitHub Action can optionally set up the application version/release, generate

--- a/code-scanning/frogbot-scan-and-fix.yml
+++ b/code-scanning/frogbot-scan-and-fix.yml
@@ -21,7 +21,7 @@ jobs:
   create-fix-pull-requests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: jfrog/frogbot@5d9c42c30f1169d8be4ba5510b40e75ffcbbc2a9  # v2.21.2
         env:

--- a/code-scanning/frogbot-scan-pr.yml
+++ b/code-scanning/frogbot-scan-pr.yml
@@ -24,7 +24,7 @@ jobs:
     # Read more here (Install Frogbot Using GitHub Actions): https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot/setup-frogbot/setup-frogbot-using-github-actions
     environment: frogbot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/code-scanning/hadolint.yml
+++ b/code-scanning/hadolint.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run hadolint
         uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183

--- a/code-scanning/jfrog-sast.yml
+++ b/code-scanning/jfrog-sast.yml
@@ -33,7 +33,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/code-scanning/jfrog-sast.yml
+++ b/code-scanning/jfrog-sast.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
 
     - name: Install and configure JFrog CLI
       run: |

--- a/code-scanning/jscrambler-code-integrity.yml
+++ b/code-scanning/jscrambler-code-integrity.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/code-scanning/jscrambler-code-integrity.yml
+++ b/code-scanning/jscrambler-code-integrity.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: npm ci

--- a/code-scanning/kubesec.yml
+++ b/code-scanning/kubesec.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run kubesec scanner
         uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14

--- a/code-scanning/lintr.yml
+++ b/code-scanning/lintr.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup R
         uses: r-lib/actions/setup-r@4e1feaf90520ec1215d1882fdddfe3411c08e492

--- a/code-scanning/mayhem-for-api.yml
+++ b/code-scanning/mayhem-for-api.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Run your API in the background. Ideally, the API would run in debug
       # mode & send stacktraces back on "500 Internal Server Error" responses

--- a/code-scanning/mobsf.yml
+++ b/code-scanning/mobsf.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup python
         uses: actions/setup-python@v3

--- a/code-scanning/mobsf.yml
+++ b/code-scanning/mobsf.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 

--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure CMake
         run: cmake -B ${{ env.build }}

--- a/code-scanning/msvc.yml
+++ b/code-scanning/msvc.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Upload SARIF file as an Artifact to download and view
       # - name: Upload SARIF as an Artifact
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v6
       #   with:
       #     name: sarif-file
       #     path: ${{ steps.run-analysis.outputs.sarif }}

--- a/code-scanning/neuralegion.yml
+++ b/code-scanning/neuralegion.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-18.04
     name: A job to run a Nexploit scan
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Start Nexploit Scan 🏁
         id: start
         uses: NeuraLegion/run-scan@29ebd17b4fd6292ce7a238a59401668953b37fbe

--- a/code-scanning/njsscan.yml
+++ b/code-scanning/njsscan.yml
@@ -30,7 +30,7 @@ jobs:
     name: njsscan code scanning
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@7237412fdd36af517e2745077cedbf9d6900d711

--- a/code-scanning/nowsecure-mobile-sbom.yml
+++ b/code-scanning/nowsecure-mobile-sbom.yml
@@ -42,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build your application
         run: ./gradlew assembleDebug              # Update this to build your Android or iOS application

--- a/code-scanning/nowsecure.yml
+++ b/code-scanning/nowsecure.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build your application
         run: ./gradlew assembleDebug              # Update this to build your Android or iOS application

--- a/code-scanning/ossar.yml
+++ b/code-scanning/ossar.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Ensure a compatible version of dotnet is installed.
     # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.

--- a/code-scanning/ossar.yml
+++ b/code-scanning/ossar.yml
@@ -40,7 +40,7 @@ jobs:
     # GitHub hosted runners already have a compatible version of dotnet installed and this step may be skipped.
     # For self-hosted runners, ensure dotnet version 3.1.201 or later is installed by including this action:
     # - name: Install .NET
-    #   uses: actions/setup-dotnet@v4
+    #   uses: actions/setup-dotnet@v5
     #   with:
     #     dotnet-version: '3.1.x'
 

--- a/code-scanning/phpmd.yml
+++ b/code-scanning/phpmd.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@aa1fe473f9c687b6fb896056d771232c0bc41161

--- a/code-scanning/pmd.yml
+++ b/code-scanning/pmd.yml
@@ -24,7 +24,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:

--- a/code-scanning/pmd.yml
+++ b/code-scanning/pmd.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/code-scanning/policy-validator-cfn.yaml
+++ b/code-scanning/policy-validator-cfn.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # checkout the repo for workflow to access the contents
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       # Configure AWS Credentials. More configuration details here - https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502

--- a/code-scanning/policy-validator-tf.yaml
+++ b/code-scanning/policy-validator-tf.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # checkout the repo for workflow to access the contents
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       # Configure AWS Credentials. More configuration details here- https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502

--- a/code-scanning/powershell.yml
+++ b/code-scanning/powershell.yml
@@ -29,7 +29,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f

--- a/code-scanning/prisma.yml
+++ b/code-scanning/prisma.yml
@@ -34,7 +34,7 @@ jobs:
     name: Run Prisma Cloud IaC Scan to check
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: iac-scan
         name: Run Scan on CFT files in the repository
         uses: prisma-cloud-shiftleft/iac-scan-action@53278c231c438216d99b463308a3cbed351ba0c3

--- a/code-scanning/psalm.yml
+++ b/code-scanning/psalm.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Psalm Security Scan
         uses: psalm/psalm-github-security-scan@f3e6fd9432bc3e44aec078572677ce9d2ef9c287

--- a/code-scanning/puppet-lint.yml
+++ b/code-scanning/puppet-lint.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0

--- a/code-scanning/pyre.yml
+++ b/code-scanning/pyre.yml
@@ -33,7 +33,7 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/code-scanning/pysa.yml
+++ b/code-scanning/pysa.yml
@@ -35,7 +35,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/code-scanning/rubocop.yml
+++ b/code-scanning/rubocop.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If running on a self-hosted runner, check it meets the requirements
     # listed at https://github.com/ruby/setup-ruby#using-self-hosted-runners

--- a/code-scanning/rust-clippy.yml
+++ b/code-scanning/rust-clippy.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1

--- a/code-scanning/scorecard.yml
+++ b/code-scanning/scorecard.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/code-scanning/scorecard.yml
+++ b/code-scanning/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 

--- a/code-scanning/securitycodescan.yml
+++ b/code-scanning/securitycodescan.yml
@@ -21,7 +21,7 @@ jobs:
   SCS:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: nuget/setup-nuget@04b0c2b8d1b97922f67eca497d7cf0bf17b8ffe1
       - uses: microsoft/setup-msbuild@v1.0.2
 

--- a/code-scanning/semgrep.yml
+++ b/code-scanning/semgrep.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Scan code using project's configuration on https://semgrep.dev/manage
       - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735

--- a/code-scanning/snyk-container.yml
+++ b/code-scanning/snyk-container.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build a Docker image
       run: docker build -t your/image-to-test .
     - name: Run Snyk to check Docker image for vulnerabilities

--- a/code-scanning/snyk-infrastructure.yml
+++ b/code-scanning/snyk-infrastructure.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning

--- a/code-scanning/snyk-security.yml
+++ b/code-scanning/snyk-security.yml
@@ -35,7 +35,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Snyk CLI to check for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the SAST issues to GitHub Code Scanning

--- a/code-scanning/snyk-security.yml
+++ b/code-scanning/snyk-security.yml
@@ -43,7 +43,7 @@ jobs:
 
         # For Snyk Open Source you must first set up the development environment for your application's dependencies
         # For example for Node
-        #- uses: actions/setup-node@v4
+        #- uses: actions/setup-node@v6
         #  with:
         #    node-version: 20
 

--- a/code-scanning/sobelow.yml
+++ b/code-scanning/sobelow.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: run-action
         uses: sobelow/action@1afd6d2cae70ae8bd900b58506f54487ed863912
       - name: Upload report

--- a/code-scanning/stackhawk.yml
+++ b/code-scanning/stackhawk.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Start your service
         run: ./your-service.sh &                  # ✏️ Update this to run your own service to be scanned

--- a/code-scanning/synopsys-action.yml
+++ b/code-scanning/synopsys-action.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Synopsys Action
         uses: synopsys-sig/synopsys-action@v1.6.0
         with:

--- a/code-scanning/synopsys-io.yml
+++ b/code-scanning/synopsys-io.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Synopsys Intelligent Security Scan
       id: prescription

--- a/code-scanning/sysdig-scan.yml
+++ b/code-scanning/sysdig-scan.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Build the Docker image
       # Tag image to be built

--- a/code-scanning/tfsec.yml
+++ b/code-scanning/tfsec.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run tfsec
         uses: aquasecurity/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608

--- a/code-scanning/trivy.yml
+++ b/code-scanning/trivy.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build an image from Dockerfile
         run: |

--- a/code-scanning/veracode.yml
+++ b/code-scanning/veracode.yml
@@ -42,7 +42,7 @@ jobs:
     - run: curl --silent --show-error --fail -O https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
     - run: unzip -o pipeline-scan-LATEST.zip
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         java-version: 8
         distribution: 'temurin'

--- a/code-scanning/veracode.yml
+++ b/code-scanning/veracode.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it and copies all sources into ZIP file for submitting for analysis. Replace this section with your applications build steps
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: ''
 

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -62,7 +62,7 @@ jobs:
       # Set up the correct Java version for your project
       # Please comment out, if your project does not contain Java source code.
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'temurin'

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       # Check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Set up the correct Java version for your project
       # Please comment out, if your project does not contain Java source code.

--- a/code-scanning/xanitizer.yml
+++ b/code-scanning/xanitizer.yml
@@ -87,7 +87,7 @@ jobs:
           license: ${{ secrets.XANITIZER_LICENSE }}
 
       # Archiving the findings list reports
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: Xanitizer-Reports
           path: |

--- a/code-scanning/zscaler-iac-scan.yml
+++ b/code-scanning/zscaler-iac-scan.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name : Code Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name : Zscaler IAC Scan
         uses : ZscalerCWP/Zscaler-IaC-Action@8d2afb33b10b4bd50e2dc2c932b37c6e70ac1087
         id : zscaler-iac-scan

--- a/code-scanning/zscan.yml
+++ b/code-scanning/zscan.yml
@@ -36,7 +36,7 @@ jobs:
       actions: read           # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Execute gradle build
       run: ./gradlew build    # Change this to build your mobile application

--- a/deployments/alibabacloud.yml
+++ b/deployments/alibabacloud.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # 1.1 Login to ACR
     - name: Login to ACR with the AccessKey pair
@@ -76,7 +76,7 @@ jobs:
         tag: "${{ env.TAG }}"
 
     # 2.1 (Optional) Login to ACR EE
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Login to ACR EE with the AccessKey pair
       uses: aliyun/acr-login@v1
       with:

--- a/deployments/aws.yml
+++ b/deployments/aws.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/deployments/azure-container-webapp.yml
+++ b/deployments/azure-container-webapp.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0

--- a/deployments/azure-functions-app-container.yml
+++ b/deployments/azure-functions-app-container.yml
@@ -40,7 +40,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: 'Login via Azure CLI'
       uses: azure/login@v1

--- a/deployments/azure-functions-app-dotnet.yml
+++ b/deployments/azure-functions-app-dotnet.yml
@@ -33,7 +33,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-functions-app-dotnet.yml
+++ b/deployments/azure-functions-app-dotnet.yml
@@ -42,7 +42,7 @@ jobs:
     #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/deployments/azure-functions-app-java-gradle.yml
+++ b/deployments/azure-functions-app-java-gradle.yml
@@ -39,7 +39,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-functions-app-java-gradle.yml
+++ b/deployments/azure-functions-app-java-gradle.yml
@@ -48,7 +48,7 @@ jobs:
     #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{ env.DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}

--- a/deployments/azure-functions-app-java.yml
+++ b/deployments/azure-functions-app-java.yml
@@ -34,7 +34,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-functions-app-java.yml
+++ b/deployments/azure-functions-app-java.yml
@@ -43,7 +43,7 @@ jobs:
     #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{ env.DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}

--- a/deployments/azure-functions-app-nodejs.yml
+++ b/deployments/azure-functions-app-nodejs.yml
@@ -44,7 +44,7 @@ jobs:
     #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup Node ${{ env.NODE_VERSION }} Environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 

--- a/deployments/azure-functions-app-nodejs.yml
+++ b/deployments/azure-functions-app-nodejs.yml
@@ -35,7 +35,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-functions-app-powershell.yml
+++ b/deployments/azure-functions-app-powershell.yml
@@ -32,7 +32,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-functions-app-python.yml
+++ b/deployments/azure-functions-app-python.yml
@@ -42,7 +42,7 @@ jobs:
     #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 

--- a/deployments/azure-functions-app-python.yml
+++ b/deployments/azure-functions-app-python.yml
@@ -33,7 +33,7 @@ jobs:
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
     # - name: 'Login via Azure CLI'

--- a/deployments/azure-kubernetes-service-helm.yml
+++ b/deployments/azure-kubernetes-service-helm.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login
@@ -79,7 +79,7 @@ jobs:
     needs: [buildImage]
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login

--- a/deployments/azure-kubernetes-service-kompose.yml
+++ b/deployments/azure-kubernetes-service-kompose.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login
@@ -77,7 +77,7 @@ jobs:
     needs: [buildImage]
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login

--- a/deployments/azure-kubernetes-service-kustomize.yml
+++ b/deployments/azure-kubernetes-service-kustomize.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login
@@ -77,7 +77,7 @@ jobs:
     needs: [buildImage]
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login

--- a/deployments/azure-kubernetes-service.yml
+++ b/deployments/azure-kubernetes-service.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login
@@ -73,7 +73,7 @@ jobs:
     needs: [buildImage]
     steps:
       # Checks out the repository this file is in
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Logs in with your Azure credentials
       - name: Azure login

--- a/deployments/azure-staticwebapp.yml
+++ b/deployments/azure-staticwebapp.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Build And Deploy

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -45,7 +45,7 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up dependency caching for faster builds
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -59,7 +59,7 @@ jobs:
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: .net-app
           path: ${{env.DOTNET_ROOT}}/myapp

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -45,7 +45,7 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up dependency caching for faster builds
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: .net-app
 

--- a/deployments/azure-webapps-dotnet-core.yml
+++ b/deployments/azure-webapps-dotnet-core.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: .net-app
 

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Java version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.DISTRIBUTION }}

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -50,7 +50,7 @@ jobs:
         run: gradle build
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: java-app
           path: '${{ github.workspace }}/build/libs/*.jar'

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar-gradle.yml
+++ b/deployments/azure-webapps-java-jar-gradle.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java version
         uses: actions/setup-java@v4

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Java version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.DISTRIBUTION }}

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -50,7 +50,7 @@ jobs:
         run: mvn clean install
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: java-app
           path: '${{ github.workspace }}/target/*.jar'

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: java-app
 

--- a/deployments/azure-webapps-java-jar.yml
+++ b/deployments/azure-webapps-java-jar.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java version
         uses: actions/setup-java@v4

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -49,7 +49,7 @@ jobs:
         npm run test --if-present
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: node-app
         path: .

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: node-app
 

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: node-app
 

--- a/deployments/azure-webapps-node.yml
+++ b/deployments/azure-webapps-node.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -57,7 +57,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Set up dependency caching for faster installs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: steps.check_files.outputs.files_exists == 'true'
         with:
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c0b4c8c8ebed23eca9ec2802474895d105b11bc

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: php-app
 

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -70,7 +70,7 @@ jobs:
         run: composer validate --no-check-publish && composer install --prefer-dist --no-progress
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: php-app
           path: .

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -57,7 +57,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Set up dependency caching for faster installs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: steps.check_files.outputs.files_exists == 'true'
         with:
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/deployments/azure-webapps-php.yml
+++ b/deployments/azure-webapps-php.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: php-app
 

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: python-app
           path: .

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python version
         uses: actions/setup-python@v3.0.0

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python version
-        uses: actions/setup-python@v3.0.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python version
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -55,7 +55,7 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
 
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-app
           path: |

--- a/deployments/azure-webapps-python.yml
+++ b/deployments/azure-webapps-python.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: python-app
           path: .

--- a/deployments/google-cloudrun-docker.yml
+++ b/deployments/google-cloudrun-docker.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # actions/checkout@v6
 
       # Configure Workload Identity Federation and generate an access token.
       #

--- a/deployments/google-cloudrun-source.yml
+++ b/deployments/google-cloudrun-source.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # actions/checkout@v6
 
       # Configure Workload Identity Federation and generate an access token.
       #

--- a/deployments/google.yml
+++ b/deployments/google.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # actions/checkout@v6
 
       # Configure Workload Identity Federation and generate an access token.
       #

--- a/deployments/ibm.yml
+++ b/deployments/ibm.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Download and Install IBM Cloud CLI
     - name: Install IBM Cloud CLI

--- a/deployments/octopusdeploy.yml
+++ b/deployments/octopusdeploy.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0

--- a/deployments/openshift.yml
+++ b/deployments/openshift.yml
@@ -124,7 +124,7 @@ jobs:
           }
 
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Determine app name
       if: env.APP_NAME == ''

--- a/deployments/openshift.yml
+++ b/deployments/openshift.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
     - name: Check for required secrets
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: |
           const secrets = {

--- a/deployments/tencent.yml
+++ b/deployments/tencent.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Build
     - name: Build Docker image

--- a/deployments/terraform.yml
+++ b/deployments/terraform.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform

--- a/pages/astro.yml
+++ b/pages/astro.yml
@@ -73,7 +73,7 @@ jobs:
             --base "${{ steps.pages.outputs.base_path }}"
         working-directory: ${{ env.BUILD_PATH }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ env.BUILD_PATH }}/dist
 

--- a/pages/astro.yml
+++ b/pages/astro.yml
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}

--- a/pages/astro.yml
+++ b/pages/astro.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
         run: |

--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -80,7 +80,7 @@ jobs:
           PREFIX_PATHS: 'true'
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 

--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
         run: |

--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -65,7 +65,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: gatsby
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             public

--- a/pages/gatsby.yml
+++ b/pages/gatsby.yml
@@ -52,7 +52,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}

--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -57,7 +57,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 

--- a/pages/hugo.yml
+++ b/pages/hugo.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup Pages

--- a/pages/jekyll-gh-pages.yml
+++ b/pages/jekyll-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/pages/jekyll-gh-pages.yml
+++ b/pages/jekyll-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll

--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4

--- a/pages/jekyll.yml
+++ b/pages/jekyll.yml
@@ -50,7 +50,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/pages/mdbook.yml
+++ b/pages/mdbook.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build with mdBook
         run: mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./book
 

--- a/pages/mdbook.yml
+++ b/pages/mdbook.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./out
 

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
         run: |

--- a/pages/nextjs.yml
+++ b/pages/nextjs.yml
@@ -62,7 +62,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
         run: |

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -47,7 +47,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Static HTML export with Nuxt
         run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
 

--- a/pages/nuxtjs.yml
+++ b/pages/nuxtjs.yml
@@ -60,7 +60,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: nuxt
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             dist

--- a/pages/static.yml
+++ b/pages/static.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: '.'

--- a/pages/static.yml
+++ b/pages/static.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
# Summary

I used data from the [check-outdateds-actions](https://github.com/actions/starter-workflows/pull/3127) for the research to do this work.

This pull request carefully bumps the version of official CI GitHub Actions to a newer or latest version. 

This helps everyone because it will make it easier for us all to use the new runners when available. And it will help us see the new GitHub Actions and their features, rather than starting out a few versions behind.

- ✅ If the new or latest version supports the same syntax as the current usage, then the upgrade is in scope for this PR.
- ✅ If this repo currently pins a version because it wants a specific feature, but that was later introduced in a public maintained release of the updated action then updating that action is in scope for this PR.
- ❌ Any changes that require major refactoring because of changes in a GitHub Action are out of scope for this PR. But we should do that work later as a separate initiative. (I have not identified any specific cases of this.)
- ❌ Any changes to action versions other than `actions/...` are OUT of scope for this PR.
- ⚠️ Any formatting changes are out of scope of this PR. If I was already touching some part I may have fix formatting in just that part. But if this is unwelcome please tell me or send a recommendation commit and I can pull that in.


---

<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

^^ Not applicable. This is not a new workflow.

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [x] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [x] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [x] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [x] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] Should specify least privileged [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _CI_ workflows, the workflow:**

- [x] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [x] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [x] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [x] Packaging workflows should run on `release` with `types: [ created ]`.
- [x] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [x] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [x] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [x] `name`: Name of the Code Scanning integration.
  - [x] `creator`: Name of the organization/user producing the Code Scanning integration.
  - [x] `description`: Short description of the Code Scanning integration.
  - [x] `categories`: Array of languages supported by the Code Scanning integration.
  - [x] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [x] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [x] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [x] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.
