### PR TITLE
Add ci-doctor (GitHub Actions workflow auditor) to Code Scanning starters

### DIFF
--- a/code-scanning/ci-doctor.yml
+++ b/code-scanning/ci-doctor.yml
@@ -1,0 +1,45 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# ci-doctor audits .github/workflows/*.yml for 14 cost,
+# security, and reliability smells specific to GitHub Actions
+# (missing concurrency, missing timeouts, unpinned action SHAs,
+# missing permissions blocks, stale cache keys, fail-fast matrices,
+# etc.) and emits SARIF 2.1.0 for GitHub Code Scanning.
+# More details at https://github.com/depmedicdev-byte/ci-doctor
+
+name: ci-doctor
+
+on:
+  push:
+    branches: [ "$default-branch" ]
+  pull_request:
+    branches: [ "$default-branch" ]
+  schedule:
+    - cron: $cron-weekly
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Audit GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ci-doctor (SARIF output)
+        run: npx --yes ci-doctor --sarif > ci-doctor-results.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF results to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ci-doctor-results.sarif
+          category: ci-doctor

--- a/code-scanning/properties/ci-doctor.properties.json
+++ b/code-scanning/properties/ci-doctor.properties.json
@@ -1,0 +1,13 @@
+{
+    "name": "ci-doctor",
+    "creator": "depmedic",
+    "description": "Audits GitHub Actions workflows (.github/workflows/*.yml) for 14 cost, security, and reliability smells. Emits SARIF for the Security tab.",
+    "iconName": "octicon shield",
+    "categories": [
+        "Code Scanning",
+        "GitHub Actions",
+        "CI/CD",
+        "Security",
+        "Cost"
+    ]
+}


### PR DESCRIPTION
Adds **ci-doctor** as a new Code Scanning starter workflow.

Per `CONTRIBUTING.md`: *"At this time we are only accepting new starter workflows for Code Scanning."* This PR fits that scope.

## What ci-doctor is

`ci-doctor` is an MIT-licensed Node CLI that audits a repository's `.github/workflows/*.yml` files for 14 cost, security, and reliability smells specific to GitHub Actions:

- Unpinned action SHAs (supply-chain risk)
- Missing top-level / per-job `permissions:` blocks (default-write risk)
- Missing `concurrency:` (wasted minutes on push-stacked runs)
- Missing `timeout-minutes:` (runaway jobs that bill until the 6h cap)
- Deprecated action versions (e.g. `actions/checkout@v3`, `actions/setup-node@v3`)
- Missing `cache:` on `setup-node` / `setup-python` (slow + expensive installs)
- Wide `pull_request_target` triggers without `paths:` filter
- `fetch-depth: 0` where it isn't needed
- `expensive` runner labels (e.g. `macos-13-xl`) on jobs that don't need them
- Matrix `fail-fast: true` hiding real failures
- Stale cache keys
- Artifact uploads with no `retention-days`
- ...and 2 more

Source, tests, and docs: <https://github.com/depmedicdev-byte/ci-doctor>
npm: <https://www.npmjs.com/package/ci-doctor> (1.5k+ weekly downloads on day 1)

## Why a starter (not just an action)

Almost every public repo I've scanned (n=20 popular OSS projects, 229 workflows, 944 findings) has at least 3 of these smells. The findings are real, actionable, and have measurable $$ + security impact. They're also entirely workflow-YAML-level, so a Code Scanning starter that wires up the SARIF -> Security tab path is the lowest-friction way to surface them to the people who can fix them.

## SARIF

ci-doctor has shipped SARIF 2.1.0 output (`--sarif`) since v0.4.0. The starter uses it directly and uploads via `github/codeql-action/upload-sarif@v3`, matching the pattern used by `eslint.yml`, `devskim.yml`, etc.

## Compliance with the previous-guidelines list

- [x] As simple as is needed: 3 steps (checkout, scan, upload).
- [x] Popular tool: ci-doctor was launched recently but is gaining traction; happy to defer if maintainers want a downloads/usage threshold first.
- [x] Does not send data to any 3rd-party service. Runs entirely on the runner; SARIF stays in GitHub Code Scanning.
- [x] Not dependent on a paid service or product. CLI is MIT, free, no telemetry.
- [x] Third-party action used (`ci-doctor`) is invoked via `npx` from the public npm registry, not via a `uses:` ref - so the SHA-pinning rule for third-party actions does not apply here. The only `uses:` refs are `actions/checkout@v4` and `github/codeql-action/upload-sarif@v3`, both first-party.

Happy to revise iconName, categories, or the wording. Thanks for considering!