### PR TITLE
Update to auto-assign-issue v3

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v1.11.0
+              uses: pozil/auto-assign-issue@v3.0.0
               with:
                   assignees: phantsure,tiwarishub,anuragc617,vsvipul,bishal-pdmsft
                   numOfAssignee: 1


### PR DESCRIPTION
The current version is using node16 which has been deprecated for a long time