### PR TITLE
Update to labeler v6

### DIFF
--- a/.github/workflows/labeler-triage.yml
+++ b/.github/workflows/labeler-triage.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The current action is using node20 which is deprecated

@salmanmkc updated this specific action...