### PR TITLE
Add "Composer audit" starter workflows & metadata

### DIFF
--- a/code-scanning/composer-audit.yml
+++ b/code-scanning/composer-audit.yml
@@ -1,0 +1,60 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# ******** NOTE ********
+# If you do not commit composer.lock or require package installations before auditing:
+#
+#   1. Set up appropriate `php-version`
+#   2. Run `$ composer install` (with `COMPOSER_AUTH` if applicable)
+#   3. Run `$ composer audit` without the `--locked` flag
+#
+# See: https://github.com/typisttech/composer-audit-to-sarif-action#audit-based-on-installed-packages
+
+name: Composer audit
+
+on:
+  push:
+    branches: [ $default-branch, $protected-branches ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ $default-branch ]
+  schedule:
+    - cron: $cron-weekly
+
+permissions:
+  contents: read # for actions/checkout to fetch code
+  security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+jobs:
+  composer-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            composer.json
+            composer.lock
+          sparse-checkout-cone-mode: false
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: latest
+          coverage: none
+
+      - run: composer audit --locked --format json > audit.json
+        continue-on-error: true
+        # env:
+        #  COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }} # if applicable
+
+      - uses: typisttech/composer-audit-to-sarif-action@b92b7e7b6e54c84918cf6a5e8ffe8058d6749f9e #v0.1.4
+        id: comsarif
+        with:
+          audit: audit.json
+
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.comsarif.outputs.sarif }}

--- a/code-scanning/properties/composer-audit.properties.json
+++ b/code-scanning/properties/composer-audit.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Composer audit",
+    "description": "Upload Composer audit reports as code scanning alerts",
+    "iconName": "php",
+    "creator": "Typist Tech Limited",
+    "categories": [
+        "Code Scanning",
+        "PHP",
+        "Composer"
+    ]
+}


### PR DESCRIPTION
<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [x] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [x] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [x] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [x] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [x] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [x] Should specify least privileged [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _Code Scanning_ workflows, the workflow:**

- [x] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [x] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [x] `name`: Name of the Code Scanning integration.
  - [x] `creator`: Name of the organization/user producing the Code Scanning integration.
  - [x] `description`: Short description of the Code Scanning integration.
  - [x] `categories`: Array of languages supported by the Code Scanning integration.
  - [x] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [x] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [x] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [x] Automation and CI workflows cannot be dependent on a paid service or product.

---

Add "Composer audit" starter workflows & metadata

- `shivammathur/setup-php` is used to install PHP & Composer
- `typisttech/composer-audit-to-sarif-action` to install [ComSARIF](https://github.com/typisttech/comsarif) which turn Composer audit reports into SARIF formats